### PR TITLE
Window maximalize support

### DIFF
--- a/dev/Core/BaseEngine.cs
+++ b/dev/Core/BaseEngine.cs
@@ -27,6 +27,7 @@ namespace UltimaXNA.Core
     {
         public static InputState Input = new InputState();
         public static GUIState UserInterface = new GUIState();
+        public static GraphicsDeviceManager GraphicsDeviceManager;
 
         public BaseEngine(int width, int height)
         {
@@ -81,16 +82,16 @@ namespace UltimaXNA.Core
         // Some settings to designate a screen size and fps limit.
         void setupGraphicsDeviceManager(int width, int height)
         {
-            GraphicsDeviceManager graphicsDeviceManager = new GraphicsDeviceManager(this);
-            graphicsDeviceManager.PreferredBackBufferWidth = width;
-            graphicsDeviceManager.PreferredBackBufferHeight = height;
-            graphicsDeviceManager.SynchronizeWithVerticalRetrace = false;
-            graphicsDeviceManager.PreparingDeviceSettings += onPreparingDeviceSettings;
+            GraphicsDeviceManager = new GraphicsDeviceManager(this);
+            GraphicsDeviceManager.PreferredBackBufferWidth = width;
+            GraphicsDeviceManager.PreferredBackBufferHeight = height;
+            GraphicsDeviceManager.SynchronizeWithVerticalRetrace = false;
+            GraphicsDeviceManager.PreparingDeviceSettings += OnPreparingDeviceManagerSettings;
             this.IsFixedTimeStep = false;
-            graphicsDeviceManager.ApplyChanges();
+            GraphicsDeviceManager.ApplyChanges();
         }
 
-        static void onPreparingDeviceSettings(object sender, PreparingDeviceSettingsEventArgs e)
+        static void OnPreparingDeviceManagerSettings(object sender, PreparingDeviceSettingsEventArgs e)
         {
             e.GraphicsDeviceInformation.PresentationParameters.RenderTargetUsage = RenderTargetUsage.PreserveContents;
         }

--- a/dev/Core/Program.cs
+++ b/dev/Core/Program.cs
@@ -12,7 +12,7 @@ namespace UltimaXNA.Core
         static void Main(string[] args)
         {
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
-            using (UltimaEngine engine = new UltimaEngine(800, 600))
+            using (UltimaEngine engine = new UltimaEngine(640, 480))
             {
                 engine.Run();
             }

--- a/dev/Core/Rendering/SpriteBatch3D.cs
+++ b/dev/Core/Rendering/SpriteBatch3D.cs
@@ -36,6 +36,7 @@ namespace UltimaXNA.Rendering
 
         private Effect m_effect;
         private BoundingBox m_boundingBox;
+        private bool forGUI;
 
         static float Z = 0;
         public static void ResetZ()
@@ -43,17 +44,37 @@ namespace UltimaXNA.Rendering
             Z = 0;
         }
 
-        public SpriteBatch3D(Game game)
+        public SpriteBatch3D(Game game, bool gui)
         {
             m_Game = game;
+            forGUI = gui;
 
-            m_boundingBox = new BoundingBox(new Vector3(0, 0, Int32.MinValue), new Vector3(GraphicsDevice.Viewport.Width, GraphicsDevice.Viewport.Height, Int32.MaxValue));
+            if (gui)
+            {
+                m_boundingBox = new BoundingBox(new Vector3(0, 0, Int32.MinValue),
+                    new Vector3(GraphicsDevice.Viewport.Width, GraphicsDevice.Viewport.Height, Int32.MaxValue));
+            }
+            else m_boundingBox = new BoundingBox(new Vector3(0, 0, Int32.MinValue),
+                    new Vector3(800, 600, Int32.MaxValue));
+
             m_drawQueue = new Dictionary<Texture2D, List<VertexPositionNormalTextureHue>>(256);
             m_indexBuffer = CreateIndexBuffer(0x1000);
             m_vertexListQueue = new Queue<List<VertexPositionNormalTextureHue>>(256);
 
             m_effect = m_Game.Content.Load<Effect>("Shaders/IsometricWorld");
             m_effect.CurrentTechnique = m_effect.Techniques["StandardEffect"];
+
+            UltimaEngine.GraphicsDeviceManager.PreparingDeviceSettings += new EventHandler<PreparingDeviceSettingsEventArgs>(GraphicsDeviceManager_PreparingDeviceSettings);
+        }
+
+        void GraphicsDeviceManager_PreparingDeviceSettings(object sender, PreparingDeviceSettingsEventArgs e)
+        {
+            if (forGUI)
+            {
+                m_boundingBox = new BoundingBox(new Vector3(0, 0, Int32.MinValue),
+                    new Vector3(e.GraphicsDeviceInformation.PresentationParameters.BackBufferWidth,
+                        e.GraphicsDeviceInformation.PresentationParameters.BackBufferHeight, Int32.MaxValue));
+            }
         }
 
         public bool DrawSimple(Texture2D texture, Vector3 position, Vector2 hue)

--- a/dev/Core/Rendering/SpriteBatchUI.cs
+++ b/dev/Core/Rendering/SpriteBatchUI.cs
@@ -24,7 +24,7 @@ namespace UltimaXNA.Rendering
 
         public SpriteBatchUI(Game game)
         {
-            m_SpriteBatch = new SpriteBatch3D(game);
+            m_SpriteBatch = new SpriteBatch3D(game, true);
         }
 
         public void Prepare()

--- a/dev/UltimaData/MusicData.cs
+++ b/dev/UltimaData/MusicData.cs
@@ -112,6 +112,8 @@ namespace UltimaXNA.UltimaData
 		static MusicData()
 		{
 			m_songList = new Hashtable ();
+
+		    if (!FileManager.Exists("Music\\Digital\\Config.txt")) return;
 			StreamReader reader = new StreamReader(FileManager.GetFile ( "Music\\Digital\\Config.txt" ));
 			String line;
 			while ((line = reader.ReadLine ()) != null)

--- a/dev/UltimaWorld/View/IsometricWorldView.cs
+++ b/dev/UltimaWorld/View/IsometricWorldView.cs
@@ -82,7 +82,7 @@ namespace UltimaXNA.UltimaWorld.View
 
         public static void Initialize(Game game)
         {
-            m_spriteBatch = new SpriteBatch3D(game);
+            m_spriteBatch = new SpriteBatch3D(game, false);
             m_vectors = new VectorRenderer(game.GraphicsDevice, game.Content);
 
             PickType = PickTypes.PickNothing;

--- a/dev/UltimaWorld/WorldModel.cs
+++ b/dev/UltimaWorld/WorldModel.cs
@@ -1,5 +1,6 @@
 ﻿using InterXLib.Input.Windows;
 using InterXLib.Patterns.MVC;
+using Microsoft.Xna.Framework.Graphics;
 using UltimaXNA.Core.Network;
 using UltimaXNA.UltimaGUI;
 using UltimaXNA.UltimaGUI.WorldGumps;
@@ -84,6 +85,12 @@ namespace UltimaXNA.UltimaWorld
 
         protected override void OnInitialize()
         {
+            UltimaEngine.GraphicsDeviceManager.PreferredBackBufferWidth =
+                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width;
+            UltimaEngine.GraphicsDeviceManager.PreferredBackBufferHeight =
+                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height;
+            UltimaEngine.GraphicsDeviceManager.ApplyChanges();
+
             m_WorldClient.Initialize();
             m_WorldClient.AfterLoginSequence();
 

--- a/dev/UltimaWorld/WorldView.cs
+++ b/dev/UltimaWorld/WorldView.cs
@@ -1,5 +1,6 @@
 ﻿using InterXLib.Display;
 using InterXLib.Patterns.MVC;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace UltimaXNA.UltimaWorld
 {
@@ -13,12 +14,16 @@ namespace UltimaXNA.UltimaWorld
         public WorldView(WorldModel model)
             : base(model)
         {
-
+            
         }
 
         public override void Draw(YSpriteBatch spritebatch, double frameTime)
         {
+            Viewport old=UltimaEngine.GraphicsDeviceManager.GraphicsDevice.Viewport;
+            UltimaEngine.GraphicsDeviceManager.GraphicsDevice.Viewport = new Viewport(0, 0, 800, 600);
             View.IsometricRenderer.Draw(Model.Map);
+            UltimaEngine.GraphicsDeviceManager.GraphicsDevice.Viewport = old;
+
             UltimaEngine.UserInterface.Draw(frameTime);
         }
     }


### PR DESCRIPTION
I have implemented window maximalization support. When game enters into world it is automatically resized to fit screen resolution. Gumps can be now moved into that black unused area. As shown on the picture:
![fullscrn](https://cloud.githubusercontent.com/assets/2104849/6705380/a3b5e4b4-cd54-11e4-935d-1a64414c400e.jpg)

We need now to draw border rectangle around the game screen. I am not familiar with your rendering system so you need to do it by yourself. For rendering game view I used Viewport. Moving with game should be easy to implement since coordinates in viewport still starts in 0,0 in top corner :-)
