### PR TITLE
Movement restriction + change how controls draw.

### DIFF
--- a/dev/Ultima/Login/States/HueTestState.cs
+++ b/dev/Ultima/Login/States/HueTestState.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using UltimaXNA.Ultima.UI;
 using UltimaXNA.Ultima.UI.Controls;
 using System.IO;
+using UltimaXNA.Core.Graphics;
 
 namespace UltimaXNA.Ultima.Login.States
 {
@@ -111,15 +112,15 @@ namespace UltimaXNA.Ultima.Login.States
 
             private Texture2D m_texture;
 
-            public override void Draw(Core.Graphics.SpriteBatchUI spriteBatch)
+            public override void Draw(SpriteBatchUI spriteBatch, Point position)
             {
                 if (m_texture == null)
                 {
                     m_texture = IO.ArtData.GetStaticTexture(m_StaticTextureID);
                     Size = new Point(m_texture.Width, m_texture.Height);
                 }
-                spriteBatch.Draw2D(m_texture, new Vector3(X, Y, 0), Utility.GetHueVector(Hue));
-                base.Draw(spriteBatch);
+                spriteBatch.Draw2D(m_texture, new Vector3(position.X, position.Y, 0), Utility.GetHueVector(Hue));
+                base.Draw(spriteBatch, position);
             }
 
             protected override void OnMouseOver(int x, int y)

--- a/dev/Ultima/UI/AControl.cs
+++ b/dev/Ultima/UI/AControl.cs
@@ -161,7 +161,6 @@ namespace UltimaXNA.Ultima.UI
         }
 
         Rectangle m_Area = Rectangle.Empty;
-        Point m_Position;
         protected int OwnerX
         {
             get
@@ -182,8 +181,8 @@ namespace UltimaXNA.Ultima.UI
                     return 0;
             }
         }
-        public int X { get { return m_Position.X; } set { m_Position.X = value; } }
-        public int Y { get { return m_Position.Y; } set { m_Position.Y = value; } }
+        public int X { get { return Position.X; } }
+        public int Y { get { return Position.Y; } }
 
         public int ScreenX
         {
@@ -227,7 +226,11 @@ namespace UltimaXNA.Ultima.UI
             }
             set
             {
-                m_Position = value;
+                if (value != m_Position)
+                {
+                    m_Position = value;
+                    OnMove();
+                }
             }
         }
         public Point Size
@@ -269,6 +272,7 @@ namespace UltimaXNA.Ultima.UI
         }
 
         UserInterfaceService m_UserInterface;
+        Point m_Position;
 
         public AControl(AControl owner, int page)
         {
@@ -320,13 +324,13 @@ namespace UltimaXNA.Ultima.UI
             }
         }
 
-        virtual public void Draw(SpriteBatchUI spriteBatch)
+        virtual public void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             if (!IsInitialized || !IsVisible)
                 return;
 
             if (Settings.Debug.ShowUIOutlines)
-                DebugDrawBounds(spriteBatch, Color.White);
+                DebugDrawBounds(spriteBatch, position, Color.White);
 
             foreach (AControl c in Children)
             {
@@ -334,10 +338,8 @@ namespace UltimaXNA.Ultima.UI
                 {
                     if (c.IsInitialized)
                     {
-                        Point saved = c.Position;
-                        c.Position = new Point(c.Position.X + Position.X, c.Position.Y + Position.Y);
-                        c.Draw(spriteBatch);
-                        c.Position = saved;
+                        Point offset = new Point(c.Position.X + position.X, c.Position.Y + position.Y);
+                        c.Draw(spriteBatch, offset);
                     }
                 }
             }
@@ -442,6 +444,11 @@ namespace UltimaXNA.Ultima.UI
         }
 
         protected virtual void OnInitialize()
+        {
+
+        }
+
+        protected virtual void OnMove()
         {
 
         }
@@ -748,7 +755,7 @@ namespace UltimaXNA.Ultima.UI
         static Texture2D s_BoundsTexture;
 #endif
 
-        protected void DebugDrawBounds(SpriteBatchUI spriteBatch, Color color)
+        protected void DebugDrawBounds(SpriteBatchUI spriteBatch, Point position, Color color)
         {
 #if DEBUG
             int hue = IO.HuesXNA.GetWebSafeHue(color);
@@ -766,10 +773,10 @@ namespace UltimaXNA.Ultima.UI
                 s_BoundsTexture.SetData<Color>(new Color[] { Color.White });
             }
 
-            spriteBatch.Draw2D(s_BoundsTexture, new Rectangle(X, Y, Width, 1), Utility.GetHueVector(hue));
-            spriteBatch.Draw2D(s_BoundsTexture, new Rectangle(X, Y + Height - 1, Width, 1), Utility.GetHueVector(hue));
-            spriteBatch.Draw2D(s_BoundsTexture, new Rectangle(X, Y, 1, Height), Utility.GetHueVector(hue));
-            spriteBatch.Draw2D(s_BoundsTexture, new Rectangle(X + Width - 1, Y, 1, Height), Utility.GetHueVector(hue));
+            spriteBatch.Draw2D(s_BoundsTexture, new Rectangle(position.X, position.Y, Width, 1), Utility.GetHueVector(hue));
+            spriteBatch.Draw2D(s_BoundsTexture, new Rectangle(position.X, position.Y + Height - 1, Width, 1), Utility.GetHueVector(hue));
+            spriteBatch.Draw2D(s_BoundsTexture, new Rectangle(position.X, position.Y, 1, Height), Utility.GetHueVector(hue));
+            spriteBatch.Draw2D(s_BoundsTexture, new Rectangle(position.X + Width - 1, position.Y, 1, Height), Utility.GetHueVector(hue));
 #endif
         #endregion
         }

--- a/dev/Ultima/UI/Controls/Button.cs
+++ b/dev/Ultima/UI/Controls/Button.cs
@@ -122,23 +122,23 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             Texture2D texture = getTextureFromMouseState();
 
             if (Caption != string.Empty)
                 m_Texture.Text = Caption;
 
-            spriteBatch.Draw2D(texture, new Rectangle(X, Y, Width, Height), Vector3.Zero);
+            spriteBatch.Draw2D(texture, new Rectangle(position.X, position.Y, Width, Height), Vector3.Zero);
 
             if (Caption != string.Empty)
             {
                 int yoffset = MouseDownOnThis ? 1 : 0;
-                m_Texture.Draw(spriteBatch, 
-                    new Point(X + (Width - m_Texture.Width) / 2,
-                        Y + yoffset + (Height - m_Texture.Height) / 2));
+                m_Texture.Draw(spriteBatch,
+                    new Point(position.X + (Width - m_Texture.Width) / 2,
+                        position.Y + yoffset + (Height - m_Texture.Height) / 2));
             }
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
 
         private Texture2D getTextureFromMouseState()

--- a/dev/Ultima/UI/Controls/CheckBox.cs
+++ b/dev/Ultima/UI/Controls/CheckBox.cs
@@ -57,16 +57,16 @@ namespace UltimaXNA.Ultima.UI.Controls
             Serial = switchID;
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
             if (IsChecked && m_Active != null)
             {
-                spriteBatch.Draw2D(m_Active, new Vector3(X, Y, 0), Vector3.Zero);
+                spriteBatch.Draw2D(m_Active, new Vector3(position.X, position.Y, 0), Vector3.Zero);
             }
             else if (!IsChecked && m_Inactive != null)
             {
-                spriteBatch.Draw2D(m_Inactive, new Vector3(X, Y, 0), Vector3.Zero);
+                spriteBatch.Draw2D(m_Inactive, new Vector3(position.X, position.Y, 0), Vector3.Zero);
             }
         }
 

--- a/dev/Ultima/UI/Controls/CheckerTrans.cs
+++ b/dev/Ultima/UI/Controls/CheckerTrans.cs
@@ -84,10 +84,10 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            spriteBatch.Draw2DTiled(CheckeredTransTexture, new Rectangle(X, Y, Width, Area.Height), Vector3.Zero);
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2DTiled(CheckeredTransTexture, new Rectangle(position.X, position.Y, Width, Area.Height), Vector3.Zero);
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/ColorPicker.cs
+++ b/dev/Ultima/UI/Controls/ColorPicker.cs
@@ -21,7 +21,7 @@ namespace UltimaXNA.Ultima.UI.Controls
         protected Texture2D m_selectedIndicator;
         protected Rectangle m_openArea;
 
-        protected Point m_hueSize;
+        protected int m_hueWidth, m_hueHeight;
         protected int[] m_hues;
 
         protected ColorPicker m_openColorPicker;
@@ -77,7 +77,8 @@ namespace UltimaXNA.Ultima.UI.Controls
 
         void buildGumpling(Rectangle area, int swatchWidth, int swatchHeight, int[] hues)
         {
-            m_hueSize = new Point(swatchWidth, swatchHeight);
+            m_hueWidth = swatchWidth;
+            m_hueHeight = swatchHeight;
             Position = new Point(area.X, area.Y);
             Size = new Point(area.Width, area.Height);
             m_hues = hues;
@@ -91,7 +92,7 @@ namespace UltimaXNA.Ultima.UI.Controls
             {
                 if (m_huesTexture == null)
                 {
-                m_huesTexture = IO.HuesXNA.HueSwatch(m_hueSize.X, m_hueSize.Y, m_hues);
+                    m_huesTexture = IO.HuesXNA.HueSwatch(m_hueWidth, m_hueHeight, m_hues);
                 m_selectedIndicator = IO.GumpData.GetGumpXNA(6000);
                 }
             }
@@ -117,22 +118,22 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             if (m_isAnOpenSwatch)
             {
-                spriteBatch.Draw2D(m_huesTexture, Area, Vector3.Zero);
+                spriteBatch.Draw2D(m_huesTexture, new Rectangle(position.X, position.Y, Width, Height), Vector3.Zero);
                 spriteBatch.Draw2D(m_selectedIndicator, new Vector3(
-                    (int)(X + (float)(Width / m_hueSize.X) * ((Index % m_hueSize.X) + 0.5f) - m_selectedIndicator.Width / 2),
-                    (int)(Y + (float)(Height / m_hueSize.Y) * ((Index / m_hueSize.X) + 0.5f) - m_selectedIndicator.Height / 2),
+                    (int)(X + (float)(Width / m_hueWidth) * ((Index % m_hueWidth) + 0.5f) - m_selectedIndicator.Width / 2),
+                    (int)(Y + (float)(Height / m_hueHeight) * ((Index / m_hueWidth) + 0.5f) - m_selectedIndicator.Height / 2),
                     0), Vector3.Zero);
             }
             else
             {
                 if (!m_isSwatchOpen)
-                    spriteBatch.Draw2D(m_huesTexture, Area, Vector3.Zero);
+                    spriteBatch.Draw2D(m_huesTexture, new Rectangle(position.X, position.Y, Width, Height), Vector3.Zero);
             }
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
 
         bool m_isAnOpenSwatch = false;
@@ -146,7 +147,7 @@ namespace UltimaXNA.Ultima.UI.Controls
                 m_openColorPicker.Dispose();
                 m_openColorPicker = null;
             }
-            m_openColorPicker = new ColorPicker(Owner, Page, m_openArea, m_hueSize.X, m_hueSize.Y, m_hues);
+            m_openColorPicker = new ColorPicker(Owner, Page, m_openArea, m_hueWidth, m_hueHeight, m_hues);
             m_openColorPicker.MouseClickEvent = onOpenSwatchClick;
             ((Gump)Owner).AddControl(m_openColorPicker);
         }
@@ -173,9 +174,9 @@ namespace UltimaXNA.Ultima.UI.Controls
         {
             if (m_isAnOpenSwatch)
             {
-                int clickRow = x / (Width / m_hueSize.X);
-                int clickColumn = y / (Height / m_hueSize.Y);
-                Index = clickRow + clickColumn * m_hueSize.X;
+                int clickRow = x / (Width / m_hueWidth);
+                int clickColumn = y / (Height / m_hueHeight);
+                Index = clickRow + clickColumn * m_hueWidth;
             }
         }
 

--- a/dev/Ultima/UI/Controls/CroppedText.cs
+++ b/dev/Ultima/UI/Controls/CroppedText.cs
@@ -54,10 +54,10 @@ namespace UltimaXNA.Ultima.UI.Controls
             m_Texture = new RenderedText(Text, width);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            m_Texture.Draw(spriteBatch, new Rectangle(X, Y, Size.X, Size.Y), 0, 0);
-            base.Draw(spriteBatch);
+            m_Texture.Draw(spriteBatch, new Rectangle(position.X, position.Y, Width, Height), 0, 0);
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/ExpandableScroll.cs
+++ b/dev/Ultima/UI/Controls/ExpandableScroll.cs
@@ -92,33 +92,30 @@ namespace UltimaXNA.Ultima.UI.Controls
             else 
             {
                 IsVisible = true;
-                m_gumplingTop.X = 0;
-                m_gumplingTop.Y = 0;
+                m_gumplingTop.Position = new Point(0, 0);
 
-                m_gumplingMiddle.X = 17;
-                m_gumplingMiddle.Y = gumplingMidY;
+                m_gumplingMiddle.Position = new Point(17, gumplingMidY);
                 m_gumplingMiddle.Width = 263;
                 m_gumplingMiddle.Height = gumplingMidHeight;
 
-                m_gumplingBottom.X = 17;
-                m_gumplingBottom.Y = gumplingBottomY;
+                m_gumplingBottom.Position = new Point(17, gumplingBottomY);
 
-                m_gumplingExpander.X = gumplingExpanderX;
-                m_gumplingExpander.Y = gumplingExpanderY;
+                m_gumplingExpander.Position = new Point(gumplingExpanderX, gumplingExpanderY);
 
                 if (m_gumplingTitle != null && m_gumplingTitle.IsInitialized)
                 {
-                    m_gumplingTitle.X = (m_gumplingTop.Width - m_gumplingTitle.Width) / 2;
-                    m_gumplingTitle.Y = (m_gumplingTop.Height - m_gumplingTitle.Height) / 2;
+                    m_gumplingTitle.Position = new Point(
+                        (m_gumplingTop.Width - m_gumplingTitle.Width) / 2,
+                        (m_gumplingTop.Height - m_gumplingTitle.Height) / 2);
                 }
             }
 
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
 
         void expander_OnMouseDown(int x, int y, MouseButton button)

--- a/dev/Ultima/UI/Controls/GumpPic.cs
+++ b/dev/Ultima/UI/Controls/GumpPic.cs
@@ -73,11 +73,11 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             Vector3 hueVector = Utility.GetHueVector(m_hue);
-            spriteBatch.Draw2D(m_texture, new Vector3(X, Y, 0), hueVector);
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2D(m_texture, new Vector3(position.X, position.Y, 0), hueVector);
+            base.Draw(spriteBatch, position);
         }
 
         protected override bool InternalHitTest(int x, int y)

--- a/dev/Ultima/UI/Controls/GumpPicTiled.cs
+++ b/dev/Ultima/UI/Controls/GumpPicTiled.cs
@@ -60,10 +60,10 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            spriteBatch.Draw2DTiled(m_bgGump, new Rectangle(X, Y, Area.Width, Area.Height), Vector3.Zero);
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2DTiled(m_bgGump, new Rectangle(position.X, position.Y, Area.Width, Area.Height), Vector3.Zero);
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/HtmlGump.cs
+++ b/dev/Ultima/UI/Controls/HtmlGump.cs
@@ -163,8 +163,7 @@ namespace UltimaXNA.Ultima.UI.Controls
                 if (m_scrollbar == null)
                 {
                     AddControl(m_scrollbar = new ScrollBar(this, 0));
-                    m_scrollbar.X = Width - 15;
-                    m_scrollbar.Y = 0;
+                    m_scrollbar.Position = new Point(Width - 15, 0);
                     m_scrollbar.Width = 15;
                     m_scrollbar.Height = Height;
                     m_scrollbar.MinValue = 0;
@@ -176,15 +175,15 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
 
             m_RenderedText.ActiveRegion = m_hrefOver;
             m_RenderedText.ActiveRegion_UseDownHue = m_clicked;
-            m_RenderedText.Draw(spriteBatch, 
-                new Rectangle(X + (Background ? 4 : 0), Y + (Background ? 4 : 0),
-                    Size.X - (Background ? 8 : 0), Size.Y - (Background ? 8 : 0)), ScrollX, ScrollY);
+            m_RenderedText.Draw(spriteBatch,
+                new Rectangle(position.X + (Background ? 4 : 0), position.Y + (Background ? 4 : 0),
+                    Width - (Background ? 8 : 0), Height - (Background ? 8 : 0)), ScrollX, ScrollY);
         }
 
         protected override bool InternalHitTest(int x, int y)

--- a/dev/Ultima/UI/Controls/ItemGumpling.cs
+++ b/dev/Ultima/UI/Controls/ItemGumpling.cs
@@ -73,15 +73,15 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             if (m_texture == null)
             {
                 m_texture = IO.ArtData.GetStaticTexture(m_item.DisplayItemID);
                 Size = new Point(m_texture.Width, m_texture.Height);
             }
-            spriteBatch.Draw2D(m_texture, new Vector3(X, Y, 0), Utility.GetHueVector(m_item.Hue));
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2D(m_texture, new Vector3(position.X, position.Y, 0), Utility.GetHueVector(m_item.Hue));
+            base.Draw(spriteBatch, position);
         }
 
         protected override bool InternalHitTest(int x, int y)

--- a/dev/Ultima/UI/Controls/ItemGumplingPaperdoll.cs
+++ b/dev/Ultima/UI/Controls/ItemGumplingPaperdoll.cs
@@ -44,7 +44,7 @@ namespace UltimaXNA.Ultima.UI.Controls
             }
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             
             if (m_texture == null)
@@ -55,8 +55,8 @@ namespace UltimaXNA.Ultima.UI.Controls
                     m_texture = IO.GumpData.GetGumpXNA(Item.ItemData.AnimID + 50000);
                 Size = new Point(m_texture.Width, m_texture.Height);
             }
-            spriteBatch.Draw2D(m_texture, new Vector3(X, Y, 0), Utility.GetHueVector(Item.Hue));
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2D(m_texture, new Vector3(position.X, position.Y, 0), Utility.GetHueVector(Item.Hue));
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/PaperdollLargeUninteractable.cs
+++ b/dev/Ultima/UI/Controls/PaperdollLargeUninteractable.cs
@@ -82,22 +82,7 @@ namespace UltimaXNA.Ultima.UI.Controls
             Position = new Point(x, y);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
-        {
-            drawLargePaperdoll_Noninteractable(spriteBatch);
-        }
-
-        int equipmentSlot(EquipSlots slotID)
-        {
-            return m_equipmentSlots[(int)slotID];
-        }
-
-        int hueSlot(EquipSlots slotID)
-        {
-            return m_hueSlots[(int)slotID];
-        }
-
-        void drawLargePaperdoll_Noninteractable(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             EquipSlots[] slotsToDraw = new EquipSlots[6] { EquipSlots.Body, EquipSlots.Footwear, EquipSlots.Legging, EquipSlots.Shirt, EquipSlots.Hair, EquipSlots.FacialHair };
             for (int i = 0; i < slotsToDraw.Length; i++)
@@ -146,8 +131,18 @@ namespace UltimaXNA.Ultima.UI.Controls
                 }
 
                 if (bodyID != 0)
-                    spriteBatch.Draw2D(IO.GumpData.GetGumpXNA(bodyID), new Vector3(X, Y, 0), Utility.GetHueVector(hue, hueGreyPixelsOnly, false));
+                    spriteBatch.Draw2D(IO.GumpData.GetGumpXNA(bodyID), new Vector3(position.X, position.Y, 0), Utility.GetHueVector(hue, hueGreyPixelsOnly, false));
             }
+        }
+
+        int equipmentSlot(EquipSlots slotID)
+        {
+            return m_equipmentSlots[(int)slotID];
+        }
+
+        int hueSlot(EquipSlots slotID)
+        {
+            return m_hueSlots[(int)slotID];
         }
     }
 }

--- a/dev/Ultima/UI/Controls/ResizePic.cs
+++ b/dev/Ultima/UI/Controls/ResizePic.cs
@@ -72,26 +72,26 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             int centerWidth = Width - m_bgGumps[0].Width - m_bgGumps[2].Width;
             int centerHeight = Height - m_bgGumps[0].Height - m_bgGumps[2].Height;
-            int line2Y = Y + m_bgGumps[0].Height;
-            int line3Y = Y + Height - m_bgGumps[6].Height;
+            int line2Y = position.Y + m_bgGumps[0].Height;
+            int line3Y = position.Y + Height - m_bgGumps[6].Height;
 
-            spriteBatch.Draw2D(m_bgGumps[0], new Vector3(X, Y, 0), Vector3.Zero);
-            spriteBatch.Draw2DTiled(m_bgGumps[1], new Rectangle(X + m_bgGumps[0].Width, Y, centerWidth, m_bgGumps[0].Height), Vector3.Zero);
-            spriteBatch.Draw2D(m_bgGumps[2], new Vector3(X + Width - m_bgGumps[2].Width, Y, 0), Vector3.Zero);
+            spriteBatch.Draw2D(m_bgGumps[0], new Vector3(position.X, position.Y, 0), Vector3.Zero);
+            spriteBatch.Draw2DTiled(m_bgGumps[1], new Rectangle(position.X + m_bgGumps[0].Width, position.Y, centerWidth, m_bgGumps[0].Height), Vector3.Zero);
+            spriteBatch.Draw2D(m_bgGumps[2], new Vector3(position.X + Width - m_bgGumps[2].Width, position.Y, 0), Vector3.Zero);
 
-            spriteBatch.Draw2DTiled(m_bgGumps[3], new Rectangle(X, line2Y, m_bgGumps[0].Width, centerHeight), Vector3.Zero);
-            spriteBatch.Draw2DTiled(m_bgGumps[4], new Rectangle(X + m_bgGumps[0].Width, line2Y, centerWidth, centerHeight), Vector3.Zero);
-            spriteBatch.Draw2DTiled(m_bgGumps[5], new Rectangle(X + Width - m_bgGumps[2].Width, line2Y, m_bgGumps[2].Width, centerHeight), Vector3.Zero);
+            spriteBatch.Draw2DTiled(m_bgGumps[3], new Rectangle(position.X, line2Y, m_bgGumps[0].Width, centerHeight), Vector3.Zero);
+            spriteBatch.Draw2DTiled(m_bgGumps[4], new Rectangle(position.X + m_bgGumps[0].Width, line2Y, centerWidth, centerHeight), Vector3.Zero);
+            spriteBatch.Draw2DTiled(m_bgGumps[5], new Rectangle(position.X + Width - m_bgGumps[2].Width, line2Y, m_bgGumps[2].Width, centerHeight), Vector3.Zero);
 
-            spriteBatch.Draw2D(m_bgGumps[6], new Vector3(X, line3Y, 0), Vector3.Zero);
-            spriteBatch.Draw2DTiled(m_bgGumps[7], new Rectangle(X + m_bgGumps[0].Width, line3Y, centerWidth, m_bgGumps[6].Height), Vector3.Zero);
-            spriteBatch.Draw2D(m_bgGumps[8], new Vector3(X + Width - m_bgGumps[2].Width, line3Y, 0), Vector3.Zero);
+            spriteBatch.Draw2D(m_bgGumps[6], new Vector3(position.X, line3Y, 0), Vector3.Zero);
+            spriteBatch.Draw2DTiled(m_bgGumps[7], new Rectangle(position.X + m_bgGumps[0].Width, line3Y, centerWidth, m_bgGumps[6].Height), Vector3.Zero);
+            spriteBatch.Draw2D(m_bgGumps[8], new Vector3(position.X + Width - m_bgGumps[2].Width, line3Y, 0), Vector3.Zero);
 
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/ScrollBar.cs
+++ b/dev/Ultima/UI/Controls/ScrollBar.cs
@@ -169,7 +169,7 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             if (!IsVisible)
                 return;
@@ -178,23 +178,23 @@ namespace UltimaXNA.Ultima.UI.Controls
             int middleHeight = BarHeight - m_gumpUpButton[0].Height - m_gumpDownButton[0].Height - m_gumpBackground[0].Height - m_gumpBackground[2].Height;
             if (middleHeight > 0)
             {
-                spriteBatch.Draw2D(m_gumpBackground[0], new Vector3(X, Y + m_gumpUpButton[0].Height, 0), Vector3.Zero);
-                spriteBatch.Draw2DTiled(m_gumpBackground[1], new Rectangle(X, Y + m_gumpUpButton[0].Height + m_gumpBackground[0].Height, m_gumpBackground[0].Width, middleHeight), Vector3.Zero);
-                spriteBatch.Draw2D(m_gumpBackground[2], new Vector3(X, Y + BarHeight - m_gumpDownButton[0].Height - m_gumpBackground[2].Height, 0), Vector3.Zero);
+                spriteBatch.Draw2D(m_gumpBackground[0], new Vector3(position.X, position.Y + m_gumpUpButton[0].Height, 0), Vector3.Zero);
+                spriteBatch.Draw2DTiled(m_gumpBackground[1], new Rectangle(position.X, position.Y + m_gumpUpButton[0].Height + m_gumpBackground[0].Height, m_gumpBackground[0].Width, middleHeight), Vector3.Zero);
+                spriteBatch.Draw2D(m_gumpBackground[2], new Vector3(position.X, position.Y + BarHeight - m_gumpDownButton[0].Height - m_gumpBackground[2].Height, 0), Vector3.Zero);
             }
             else
             {
                 middleHeight = Height - m_gumpUpButton[0].Height - m_gumpDownButton[0].Height;
-                spriteBatch.Draw2DTiled(m_gumpBackground[1], new Rectangle(X, Y + m_gumpUpButton[0].Height, m_gumpBackground[0].Width, middleHeight), Vector3.Zero);
+                spriteBatch.Draw2DTiled(m_gumpBackground[1], new Rectangle(position.X, position.Y + m_gumpUpButton[0].Height, m_gumpBackground[0].Width, middleHeight), Vector3.Zero);
             }
             // up button
-            spriteBatch.Draw2D(m_btnUpClicked ? m_gumpUpButton[1] : m_gumpUpButton[0], new Vector3(X, Y, 0), Vector3.Zero);
+            spriteBatch.Draw2D(m_btnUpClicked ? m_gumpUpButton[1] : m_gumpUpButton[0], new Vector3(position.X, position.Y, 0), Vector3.Zero);
             // down button
-            spriteBatch.Draw2D(m_btnDownClicked ? m_gumpDownButton[1] : m_gumpDownButton[0], new Vector3(X, Y + Height - m_gumpDownButton[0].Height, 0), Vector3.Zero);
+            spriteBatch.Draw2D(m_btnDownClicked ? m_gumpDownButton[1] : m_gumpDownButton[0], new Vector3(position.X, position.Y + Height - m_gumpDownButton[0].Height, 0), Vector3.Zero);
             // slider
             if (MaxValue > MinValue && middleHeight > 0)
-                spriteBatch.Draw2D(m_gumpSlider, new Vector3(X + (m_gumpBackground[0].Width - m_gumpSlider.Width) / 2, Y + m_gumpUpButton[0].Height + m_SliderPosition, 0), Vector3.Zero);
-            base.Draw(spriteBatch);
+                spriteBatch.Draw2D(m_gumpSlider, new Vector3(position.X + (m_gumpBackground[0].Width - m_gumpSlider.Width) / 2, position.Y + m_gumpUpButton[0].Height + m_SliderPosition, 0), Vector3.Zero);
+            base.Draw(spriteBatch, position);
         }
 
         protected override bool InternalHitTest(int x, int y)

--- a/dev/Ultima/UI/Controls/Slider.cs
+++ b/dev/Ultima/UI/Controls/Slider.cs
@@ -87,13 +87,13 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            spriteBatch.Draw2D(m_gumpBar[0], new Vector3(X, Y, 0), Vector3.Zero);
-            spriteBatch.Draw2DTiled(m_gumpBar[1], new Rectangle(Area.X + m_gumpBar[0].Width, Area.Y, BarWidth - m_gumpBar[2].Width - m_gumpBar[0].Width, m_gumpBar[1].Height), Vector3.Zero);
-            spriteBatch.Draw2D(m_gumpBar[2], new Vector3(Area.X + BarWidth - m_gumpBar[2].Width, Area.Y, 0), Vector3.Zero);
-            spriteBatch.Draw2D(m_gumpSlider, new Vector3(Area.X + m_sliderX, Area.Y, 0), Vector3.Zero);
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2D(m_gumpBar[0], new Vector3(position.X, position.Y, 0), Vector3.Zero);
+            spriteBatch.Draw2DTiled(m_gumpBar[1], new Rectangle(Area.X + m_gumpBar[0].Width, position.Y, BarWidth - m_gumpBar[2].Width - m_gumpBar[0].Width, m_gumpBar[1].Height), Vector3.Zero);
+            spriteBatch.Draw2D(m_gumpBar[2], new Vector3(position.X + BarWidth - m_gumpBar[2].Width, position.Y, 0), Vector3.Zero);
+            spriteBatch.Draw2D(m_gumpSlider, new Vector3(position.X + m_sliderX, position.Y, 0), Vector3.Zero);
+            base.Draw(spriteBatch, position);
         }
 
         protected override bool InternalHitTest(int x, int y)

--- a/dev/Ultima/UI/Controls/TextEntry.cs
+++ b/dev/Ultima/UI/Controls/TextEntry.cs
@@ -129,26 +129,26 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            Point caratPosition = new Point(X, Y);
+            Point caratPosition = new Point(position.X, position.Y);
 
             if (m_RenderedText.Width + m_Carat.Width <= Width)
             {
-                m_RenderedText.Draw(spriteBatch, Position);
+                m_RenderedText.Draw(spriteBatch, position);
                 caratPosition.X += m_RenderedText.Width;
             }
             else
             {
                 int textOffset = m_RenderedText.Width - (Width - m_Carat.Width);
-                m_RenderedText.Draw(spriteBatch, new Rectangle(Position.X, Position.Y, m_RenderedText.Width - textOffset, m_RenderedText.Height), textOffset, 0);
+                m_RenderedText.Draw(spriteBatch, new Rectangle(position.X, position.Y, m_RenderedText.Width - textOffset, m_RenderedText.Height), textOffset, 0);
                 caratPosition.X += (Width - m_Carat.Width);
             }
 
 
             if (m_caratBlinkOn)
                 m_Carat.Draw(spriteBatch, caratPosition);
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
 
         protected override void OnKeyboardInput(InputEventKeyboard e)

--- a/dev/Ultima/UI/Controls/TextLabel.cs
+++ b/dev/Ultima/UI/Controls/TextLabel.cs
@@ -75,10 +75,10 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            m_textRenderer.Draw(spriteBatch, Position, Utility.GetHueVector(Hue, false, false));
-            base.Draw(spriteBatch);
+            m_textRenderer.Draw(spriteBatch, position, Utility.GetHueVector(Hue, false, false));
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/TextLabelAscii.cs
+++ b/dev/Ultima/UI/Controls/TextLabelAscii.cs
@@ -48,11 +48,11 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             m_texture = ASCIIText.GetTextTexture(Text, FontID);
-            spriteBatch.Draw2D(m_texture, new Vector3(X, Y, 0), Utility.GetHueVector(Hue, true, false));
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2D(m_texture, new Vector3(position.X, position.Y, 0), Utility.GetHueVector(Hue, true, false));
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/TextLabelAsciiCropped.cs
+++ b/dev/Ultima/UI/Controls/TextLabelAsciiCropped.cs
@@ -49,12 +49,12 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             if (m_texture == null)
                 m_texture = ASCIIText.GetTextTexture(Text, FontID, Area.Width);
-            spriteBatch.Draw2D(m_texture, new Vector3(X, Y, 0), Utility.GetHueVector(Hue, true, false));
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2D(m_texture, new Vector3(position.X, position.Y, 0), Utility.GetHueVector(Hue, true, false));
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/TilePic.cs
+++ b/dev/Ultima/UI/Controls/TilePic.cs
@@ -65,10 +65,10 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            spriteBatch.Draw2D(m_texture, new Vector3(X, Y, 0), Utility.GetHueVector(0, false, false));
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2D(m_texture, new Vector3(position.X, position.Y, 0), Utility.GetHueVector(0, false, false));
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/DragWidget.cs
+++ b/dev/Ultima/UI/DragWidget.cs
@@ -55,8 +55,9 @@ namespace UltimaXNA.Ultima.UI
                 {
                     UnclipMouse();
                     m_IsMoving = false;
-                    m_DragTarget.X += (x - m_DragOriginX);
-                    m_DragTarget.Y += (y - m_DragOriginY);
+                    m_DragTarget.Position = new Point(
+                        m_DragTarget.X + (x - m_DragOriginX),
+                        m_DragTarget.Y + (y - m_DragOriginY));
                 }
             }
         }
@@ -68,8 +69,9 @@ namespace UltimaXNA.Ultima.UI
             if (m_IsMoving == true)
             {
                 ClipMouse(ref x, ref y);
-                m_DragTarget.X += (x - m_DragOriginX);
-                m_DragTarget.Y += (y - m_DragOriginY);
+                m_DragTarget.Position = new Point(
+                    m_DragTarget.X + (x - m_DragOriginX),
+                    m_DragTarget.Y + (y - m_DragOriginY));
                 m_DragOriginX = x;
                 m_DragOriginY = y;
             }

--- a/dev/Ultima/UI/UserInterfaceService.cs
+++ b/dev/Ultima/UI/UserInterfaceService.cs
@@ -35,6 +35,12 @@ namespace UltimaXNA.Ultima.UI
             m_DisposedControls = new List<AControl>();
         }
 
+        public void Dispose()
+        {
+            foreach (AControl c in m_Controls)
+                c.Dispose();
+        }
+
         SpriteBatchUI m_SpriteBatch;
         internal SpriteBatchUI SpriteBatch { get { return m_SpriteBatch; } }
 
@@ -285,7 +291,7 @@ namespace UltimaXNA.Ultima.UI
             foreach (AControl c in m_Controls)
             {
                 if (c.IsInitialized)
-                    c.Draw(m_SpriteBatch);
+                    c.Draw(m_SpriteBatch, c.Position);
             }
 
             if (Cursor != null)

--- a/dev/Ultima/World/Gumps/ChatControl.cs
+++ b/dev/Ultima/World/Gumps/ChatControl.cs
@@ -95,15 +95,15 @@ namespace UltimaXNA.Ultima.World.Gumps
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            int y = m_TextEntry.Y + Y - 6;
+            int y = m_TextEntry.Y + position.Y - 6;
             for (int i = m_TextEntries.Count - 1; i >= 0; i--)
             {
                 y -= m_TextEntries[i].TextHeight;
-                m_TextEntries[i].Draw(spriteBatch, new Point(X + 2, y));
+                m_TextEntries[i].Draw(spriteBatch, new Point(position.X + 2, y));
             }
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
 
         public override void ActivateByKeyboardReturn(int textID, string text)

--- a/dev/Ultima/World/Gumps/DebugGump.cs
+++ b/dev/Ultima/World/Gumps/DebugGump.cs
@@ -32,11 +32,11 @@ namespace UltimaXNA.Ultima.World.Gumps
             AddControl(new ResizePic(this, 0, 0, 0, 0x2436, 256 + 16, 256 + 16));
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
 
-            spriteBatch.Draw2D(((WorldView)m_World.GetView()).MiniMap.Texture, new Vector3(X + 8, Y + 8, 0), Vector3.Zero);
+            spriteBatch.Draw2D(((WorldView)m_World.GetView()).MiniMap.Texture, new Vector3(position.X + 8, position.Y + 8, 0), Vector3.Zero);
         }
     }
 }

--- a/dev/Ultima/World/Gumps/JournalGump.cs
+++ b/dev/Ultima/World/Gumps/JournalGump.cs
@@ -38,9 +38,10 @@ namespace UltimaXNA.Ultima.World.Gumps
 
         protected override void OnInitialize()
         {
+            SetSavePositionName("journal");
             base.OnInitialize();
 
-            SetSavePositionName("journal");
+            
 
             m_JournalEntries = new List<RenderedText>();
             InitializeJournalEntries();
@@ -62,11 +63,11 @@ namespace UltimaXNA.Ultima.World.Gumps
             m_ScrollBar.IsVisible = m_ScrollBar.MaxValue > m_ScrollBar.MinValue;
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
 
-            Point p = new Point(X + 36, Y + 35);
+            Point p = new Point(position.X + 36, position.Y + 35);
             int height = 0;
             int maxheight = m_ScrollBar.Value + m_EntriesHeight;
 
@@ -83,7 +84,7 @@ namespace UltimaXNA.Ultima.World.Gumps
                     if (y < 0)
                     {
                         // this entry starts above the renderable area, but exists partially within it.
-                        m_JournalEntries[i].Draw(spriteBatch, new Rectangle(p.X, Y + 35, m_JournalEntries[i].Width, m_JournalEntries[i].Height + y), 0, -y);
+                        m_JournalEntries[i].Draw(spriteBatch, new Rectangle(p.X, position.Y + 35, m_JournalEntries[i].Width, m_JournalEntries[i].Height + y), 0, -y);
                         p.Y += m_JournalEntries[i].Height + y;
                     }
                     else
@@ -97,7 +98,7 @@ namespace UltimaXNA.Ultima.World.Gumps
                 else
                 {
                     int y = maxheight - height;
-                    m_JournalEntries[i].Draw(spriteBatch, new Rectangle(p.X, Y + 35 + m_EntriesHeight - y, m_JournalEntries[i].Width, y), 0, 0);
+                    m_JournalEntries[i].Draw(spriteBatch, new Rectangle(p.X, position.Y + 35 + m_EntriesHeight - y, m_JournalEntries[i].Width, y), 0, 0);
                     // can't fit any more entries - so we break!
                     break;
                 }

--- a/dev/Ultima/World/Gumps/MiniMapGump.cs
+++ b/dev/Ultima/World/Gumps/MiniMapGump.cs
@@ -64,7 +64,7 @@ namespace UltimaXNA.Ultima.World.Gumps
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             AEntity player = EntityManager.GetPlayerObject();
             float x = (float)Math.Round((player.Position.X % 256) + player.Position.X_offset) / 256f;
@@ -75,10 +75,10 @@ namespace UltimaXNA.Ultima.World.Gumps
 
             VertexPositionNormalTextureHue[] v = new VertexPositionNormalTextureHue[4]
             {
-                new VertexPositionNormalTextureHue(new Vector3(X, Y, 0), playerPosition + new Vector3(-minimapU, -minimapV, 0), new Vector3(0, 0, 0)),
-                new VertexPositionNormalTextureHue(new Vector3(X + Size.X, Y, 0), playerPosition + new Vector3(minimapU, -minimapV, 0), new Vector3(1, 0, 0)),
-                new VertexPositionNormalTextureHue(new Vector3(X, Y + Size.Y, 0), playerPosition + new Vector3(-minimapU, minimapV, 0), new Vector3(0, 1, 0)),
-                new VertexPositionNormalTextureHue(new Vector3(X + Size.X, Y + Size.Y, 0), playerPosition + new Vector3(minimapU, minimapV, 0), new Vector3(1, 1, 0))
+                new VertexPositionNormalTextureHue(new Vector3(position.X, position.Y, 0), playerPosition + new Vector3(-minimapU, -minimapV, 0), new Vector3(0, 0, 0)),
+                new VertexPositionNormalTextureHue(new Vector3(position.X + Width, position.Y, 0), playerPosition + new Vector3(minimapU, -minimapV, 0), new Vector3(1, 0, 0)),
+                new VertexPositionNormalTextureHue(new Vector3(position.X, position.Y + Height, 0), playerPosition + new Vector3(-minimapU, minimapV, 0), new Vector3(0, 1, 0)),
+                new VertexPositionNormalTextureHue(new Vector3(position.X + Width, position.Y + Height, 0), playerPosition + new Vector3(minimapU, minimapV, 0), new Vector3(1, 1, 0))
             };
 
             spriteBatch.Draw(m_GumpTexture, v, Techniques.MiniMap);
@@ -90,7 +90,7 @@ namespace UltimaXNA.Ultima.World.Gumps
                     m_PlayerIndicator = new Texture2D(spriteBatch.GraphicsDevice, 1, 1);
                     m_PlayerIndicator.SetData<uint>(new uint[1] { 0xFFFFFFFF });
                 }
-                spriteBatch.Draw2D(m_PlayerIndicator, new Vector3(X + Size.X / 2, Y + Size.Y / 2 - 8, 0), Vector3.Zero);
+                spriteBatch.Draw2D(m_PlayerIndicator, new Vector3(position.X + Width / 2, position.Y + Height / 2 - 8, 0), Vector3.Zero);
             }
         }
 

--- a/dev/Ultima/World/Gumps/PaperDollGump.cs
+++ b/dev/Ultima/World/Gumps/PaperDollGump.cs
@@ -13,6 +13,7 @@ using UltimaXNA.Core.Network;
 using UltimaXNA.Ultima.Entities.Mobiles;
 using UltimaXNA.Ultima.UI;
 using UltimaXNA.Ultima.UI.Controls;
+using Microsoft.Xna.Framework;
 #endregion
 
 namespace UltimaXNA.Ultima.World.Gumps
@@ -123,9 +124,9 @@ namespace UltimaXNA.Ultima.World.Gumps
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
 
         public override void ActivateByButton(int buttonID)

--- a/dev/Ultima/World/Gumps/SkillsGump.cs
+++ b/dev/Ultima/World/Gumps/SkillsGump.cs
@@ -12,6 +12,7 @@ using System.Text;
 using UltimaXNA.Ultima.Player;
 using UltimaXNA.Ultima.UI;
 using UltimaXNA.Ultima.UI.Controls;
+using Microsoft.Xna.Framework;
 #endregion
 
 namespace UltimaXNA.Ultima.World.Gumps
@@ -47,8 +48,7 @@ namespace UltimaXNA.Ultima.World.Gumps
 
         public override void Update(double totalMS, double frameMS)
         {
-            m_list.X = 26;
-            m_list.Y = 33;
+            m_list.Position = new Point(26, 33);
             m_list.Width = Width - 56;
             m_list.Height = Height - 95;
             m_list.Text = buildSkillsString();

--- a/dev/Ultima/World/Gumps/StatusGump.cs
+++ b/dev/Ultima/World/Gumps/StatusGump.cs
@@ -9,6 +9,7 @@
  *
  ***************************************************************************/
 #region usings
+using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using UltimaXNA.Core.Graphics;
 using UltimaXNA.Ultima.Entities.Mobiles;
@@ -165,9 +166,9 @@ namespace UltimaXNA.Ultima.World.Gumps
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/World/Gumps/WorldControl.cs
+++ b/dev/Ultima/World/Gumps/WorldControl.cs
@@ -34,13 +34,13 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Dispose();
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
             Texture2D worldTexture = (m_Model.GetView() as WorldView).Isometric.Texture;
             m_InputMultiplier = new Vector2((float)worldTexture.Width / Width, (float)worldTexture.Height / Height);
 
-            spriteBatch.Draw2D(worldTexture, new Rectangle(X, Y, Width, Height), Vector3.Zero);
-            base.Draw(spriteBatch);
+            spriteBatch.Draw2D(worldTexture, new Rectangle(position.X, position.Y, Width, Height), Vector3.Zero);
+            base.Draw(spriteBatch, position);
         }
 
         protected override void OnMouseOver(int x, int y)

--- a/dev/Ultima/World/Gumps/WorldViewGump.cs
+++ b/dev/Ultima/World/Gumps/WorldViewGump.cs
@@ -50,22 +50,27 @@ namespace UltimaXNA.Ultima.World.Gumps
             base.Update(totalMS, frameMS);
         }
 
-        public override void Draw(SpriteBatchUI spriteBatch)
+        public override void Draw(SpriteBatchUI spriteBatch, Point position)
         {
-            CheckPosition(spriteBatch);
-            base.Draw(spriteBatch);
+            base.Draw(spriteBatch, position);
         }
 
-        private void CheckPosition(SpriteBatchUI spriteBatch)
+        protected override void OnMove()
         {
-            if (X < -BorderWidth)
-                X = -BorderWidth;
-            if (Y < -BorderHeight)
-                Y = -BorderHeight;
-            if (X + Width - BorderWidth > spriteBatch.GraphicsDevice.Viewport.Width)
-                X = spriteBatch.GraphicsDevice.Viewport.Width - (Width - BorderWidth);
-            if (Y + Height - BorderHeight > spriteBatch.GraphicsDevice.Viewport.Height)
-                Y = spriteBatch.GraphicsDevice.Viewport.Height - (Height - BorderHeight);
+            // base.OnMove(); - this would make sure that the gump remained at least half on screen, but we want more fine-grained control over movement.
+            SpriteBatchUI sb = UltimaServices.GetService<SpriteBatchUI>();
+            Point position = Position;
+
+            if (position.X < -BorderWidth)
+                position.X = -BorderWidth;
+            if (position.Y < -BorderHeight)
+                position.Y = -BorderHeight;
+            if (position.X + Width - BorderWidth > sb.GraphicsDevice.Viewport.Width)
+                position.X = sb.GraphicsDevice.Viewport.Width - (Width - BorderWidth);
+            if (position.Y + Height - BorderHeight > sb.GraphicsDevice.Viewport.Height)
+                position.Y = sb.GraphicsDevice.Viewport.Height - (Height - BorderHeight);
+
+            Position = position;
         }
 
         private void OnResize()

--- a/dev/UltimaEngine.cs
+++ b/dev/UltimaEngine.cs
@@ -154,6 +154,12 @@ namespace UltimaXNA
             }
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            UserInterface.Dispose();
+            base.Dispose(disposing);
+        }
+
         protected override void Update(GameTime gameTime)
         {
             IsFixedTimeStep = Settings.Game.IsFixedTimeStep;


### PR DESCRIPTION
- AControl.Draw now accepts parameter Point position. Control should
  draw at this position, regardless of values of its member variables.
- When a AControl's position is changed, it calls OnMove(). By default,
  OnMove keeps the control from moving off screen.
