### PR TITLE
Var renaming

### DIFF
--- a/dev/Core/IO/AsyncWriter.cs
+++ b/dev/Core/IO/AsyncWriter.cs
@@ -269,29 +269,29 @@ namespace UltimaXNA.Core.IO
 
         private class WorkerThread
         {
-            private readonly AsyncWriter m_Owner;
+            private readonly AsyncWriter m_Parent;
 
-            public WorkerThread(AsyncWriter owner)
+            public WorkerThread(AsyncWriter parent)
             {
-                m_Owner = owner;
+                m_Parent = parent;
             }
 
             public void Worker()
             {
                 m_ThreadCount++;
-                while(m_Owner.m_WriteQueue.Count > 0)
+                while(m_Parent.m_WriteQueue.Count > 0)
                 {
-                    MemoryStream mem = (MemoryStream)m_Owner.m_WriteQueue.Dequeue();
+                    MemoryStream mem = (MemoryStream)m_Parent.m_WriteQueue.Dequeue();
 
                     if(mem != null && mem.Length > 0)
                     {
-                        mem.WriteTo(m_Owner.m_File);
+                        mem.WriteTo(m_Parent.m_File);
                     }
                 }
 
-                if(m_Owner.m_Closed)
+                if(m_Parent.m_Closed)
                 {
-                    m_Owner.m_File.Close();
+                    m_Parent.m_File.Close();
                 }
 
                 m_ThreadCount--;

--- a/dev/Core/UI/AControl.cs
+++ b/dev/Core/UI/AControl.cs
@@ -153,7 +153,7 @@ namespace UltimaXNA.Core.UI
         {
             get
             {
-                return OwnerX + X;
+                return ParentX + X;
             }
         }
 
@@ -161,7 +161,7 @@ namespace UltimaXNA.Core.UI
         {
             get
             {
-                return OwnerY + Y;
+                return ParentY + Y;
             }
         }
 
@@ -288,46 +288,46 @@ namespace UltimaXNA.Core.UI
         internal event Action<AControl, int, int> MouseOutEvent;
         #endregion
 
-        #region Owner variables
-        public AControl Owner
+        #region Parent control variables
+        public AControl Parent
         {
             get;
             protected set;
         }
 
         /// <summary>
-        /// Gets the topmost owner of this control.
+        /// Gets the root (topmost, or final) parent of this control.
         /// </summary>
-        public AControl OwnerTopmost
+        public AControl RootParent
         {
             get
             {
-                if (Owner == null)
+                if (Parent == null)
                     return null;
-                AControl owner = Owner;
-                while (owner.Owner != null)
-                    owner = owner.Owner;
-                return owner;
+                AControl parent = Parent;
+                while (parent.Parent != null)
+                    parent = parent.Parent;
+                return parent;
             }
         }
 
-        private int OwnerX
+        private int ParentX
         {
             get
             {
-                if (Owner != null)
-                    return Owner.X + Owner.OwnerX;
+                if (Parent != null)
+                    return Parent.X + Parent.ParentX;
                 else
                     return 0;
             }
         }
 
-        private int OwnerY
+        private int ParentY
         {
             get
             {
-                if (Owner != null)
-                    return Owner.Y + Owner.OwnerY;
+                if (Parent != null)
+                    return Parent.Y + Parent.ParentY;
                 else
                     return 0;
             }
@@ -337,9 +337,9 @@ namespace UltimaXNA.Core.UI
         // ================================================================================
         // Ctor, Init, Dispose, Update, and Draw
         // ================================================================================
-        public AControl(AControl owner)
+        public AControl(AControl parent)
         {
-            Owner = owner;
+            Parent = parent;
             Page = 0;
             UserInterface = ServiceRegistry.GetService<UserInterfaceService>();
         }
@@ -499,26 +499,26 @@ namespace UltimaXNA.Core.UI
 
         public virtual void ActivateByButton(int buttonID)
         {
-            if (Owner != null)
-                Owner.ActivateByButton(buttonID);
+            if (Parent != null)
+                Parent.ActivateByButton(buttonID);
         }
 
         public virtual void ActivateByHREF(string href)
         {
-            if (Owner != null)
-                Owner.ActivateByHREF(href);
+            if (Parent != null)
+                Parent.ActivateByHREF(href);
         }
 
         public virtual void ActivateByKeyboardReturn(int textID, string text)
         {
-            if (Owner != null)
-                Owner.ActivateByKeyboardReturn(textID, text);
+            if (Parent != null)
+                Parent.ActivateByKeyboardReturn(textID, text);
         }
 
         public virtual void ChangePage(int pageIndex)
         {
-            if (Owner != null)
-                Owner.ChangePage(pageIndex);
+            if (Parent != null)
+                Parent.ChangePage(pageIndex);
         }
 
         // ================================================================================
@@ -648,8 +648,8 @@ namespace UltimaXNA.Core.UI
         public void MouseDown(Point position, MouseButton button)
         {
             m_LastClickPosition = position;
-            int x = (int)position.X - X - OwnerX;
-            int y = (int)position.Y - Y - OwnerY;
+            int x = (int)position.X - X - ParentX;
+            int y = (int)position.Y - Y - ParentY;
             OnMouseDown(x, y, button);
             if (MouseDownEvent != null)
                 MouseDownEvent(this, x, y, button);
@@ -657,8 +657,8 @@ namespace UltimaXNA.Core.UI
 
         public void MouseUp(Point position, MouseButton button)
         {
-            int x = (int)position.X - X - OwnerX;
-            int y = (int)position.Y - Y - OwnerY;
+            int x = (int)position.X - X - ParentX;
+            int y = (int)position.Y - Y - ParentY;
             OnMouseUp(x, y, button);
             if (MouseUpEvent != null)
                 MouseUpEvent(this, x, y, button);
@@ -670,8 +670,8 @@ namespace UltimaXNA.Core.UI
             if (Math.Abs(m_LastClickPosition.X - position.X) + Math.Abs(m_LastClickPosition.Y - position.Y) > 3)
                 m_MaxTimeForDoubleClick = 0.0f;
 
-            int x = (int)position.X - X - OwnerX;
-            int y = (int)position.Y - Y - OwnerY;
+            int x = (int)position.X - X - ParentX;
+            int y = (int)position.Y - Y - ParentY;
             OnMouseOver(x, y);
             if (MouseOverEvent != null)
                 MouseOverEvent(this, x, y);
@@ -679,8 +679,8 @@ namespace UltimaXNA.Core.UI
 
         public void MouseOut(Point position)
         {
-            int x = (int)position.X - X - OwnerX;
-            int y = (int)position.Y - Y - OwnerY;
+            int x = (int)position.X - X - ParentX;
+            int y = (int)position.Y - Y - ParentY;
             OnMouseOut(x, y);
             if (MouseOutEvent != null)
                 MouseOutEvent(this, x, y);
@@ -688,8 +688,8 @@ namespace UltimaXNA.Core.UI
 
         public void MouseClick(Point position, MouseButton button)
         {
-            int x = (int)position.X - X - OwnerX;
-            int y = (int)position.Y - Y - OwnerY;
+            int x = (int)position.X - X - ParentX;
+            int y = (int)position.Y - Y - ParentY;
 
             bool doubleClick = false;
             if (m_MaxTimeForDoubleClick != 0f)
@@ -727,29 +727,29 @@ namespace UltimaXNA.Core.UI
         {
             if (IsUncloseableWithRMB)
                 return;
-            AControl parent = Owner;
+            AControl parent = Parent;
             while (parent != null)
             {
                 if (parent.IsUncloseableWithRMB)
                     return;
-                parent = parent.Owner;
+                parent = parent.Parent;
             }
 
-            // dispose of this, or owner, if it has one, which will close this as a child.
-            if (Owner == null)
+            // dispose of this, or the parent if it has one, which will close this as a child.
+            if (Parent == null)
                 Dispose();
             else
-                Owner.CloseWithRightMouseButton();
+                Parent.CloseWithRightMouseButton();
         }
 
         public AControl[] HitTest(Point position, bool alwaysHandleMouseInput)
         {
             List<AControl> focusedControls = new List<AControl>();
 
-            bool inBounds = m_Area.Contains((int)position.X - OwnerX, (int)position.Y - OwnerY);
+            bool inBounds = m_Area.Contains((int)position.X - ParentX, (int)position.Y - ParentY);
             if (inBounds)
             {
-                if (IsPointWithinControl((int)position.X - X - OwnerX, (int)position.Y - Y - OwnerY))
+                if (IsPointWithinControl((int)position.X - X - ParentX, (int)position.Y - Y - ParentY))
                 {
                     if (alwaysHandleMouseInput || HandlesMouseInput)
                         focusedControls.Insert(0, this);

--- a/dev/Core/UI/UserInterfaceService.cs
+++ b/dev/Core/UI/UserInterfaceService.cs
@@ -306,11 +306,11 @@ namespace UltimaXNA.Core.UI
             if ((MouseOverControl != null) && (focusedControl != MouseOverControl))
             {
                 MouseOverControl.MouseOut(clippedPosition);
-                // Also let the owner control know we've been moused out (for gumps).
-                if (MouseOverControl.OwnerTopmost != null)
+                // Also let the parent control know we've been moused out (for gumps).
+                if (MouseOverControl.RootParent != null)
                 {
-                    if (focusedControl == null || MouseOverControl.OwnerTopmost != focusedControl.OwnerTopmost)
-                        MouseOverControl.OwnerTopmost.MouseOut(clippedPosition);
+                    if (focusedControl == null || MouseOverControl.RootParent != focusedControl.RootParent)
+                        MouseOverControl.RootParent.MouseOut(clippedPosition);
                 }
             }
 
@@ -402,8 +402,8 @@ namespace UltimaXNA.Core.UI
         private void MakeTopMostGump(AControl control)
         {
             AControl c = control;
-            while (c.Owner != null)
-                c = c.Owner;
+            while (c.Parent != null)
+                c = c.Parent;
 
             for (int i = 0; i < m_Controls.Count; i++)
             {
@@ -529,8 +529,8 @@ namespace UltimaXNA.Core.UI
             if (!dragTarget.IsMovable)
                 return;
 
-            while (dragTarget.Owner != null)
-                dragTarget = dragTarget.Owner;
+            while (dragTarget.Parent != null)
+                dragTarget = dragTarget.Parent;
 
             if (dragTarget.IsMovable)
             {

--- a/dev/Ultima/Login/States/HueTestState.cs
+++ b/dev/Ultima/Login/States/HueTestState.cs
@@ -103,8 +103,8 @@ namespace UltimaXNA.Ultima.Login.States
         {
             private int m_StaticTextureID = 0;
 
-            public HuedControl(AControl owner, int staticID = 0x1bf5)
-                : base(owner)
+            public HuedControl(AControl parent, int staticID = 0x1bf5)
+                : base(parent)
             {
                 HandlesMouseInput = true;
                 m_StaticTextureID = staticID;

--- a/dev/Ultima/Player/SkillData.cs
+++ b/dev/Ultima/Player/SkillData.cs
@@ -55,7 +55,7 @@ namespace UltimaXNA.Ultima.Player
 
     public class SkillEntry
     {
-        private SkillData m_Owner;
+        private SkillData m_DataParent;
 
         private int m_id;
         private int m_index;
@@ -92,8 +92,8 @@ namespace UltimaXNA.Ultima.Player
             set
             {
                 m_value = value;
-                if (m_Owner.OnSkillChanged != null)
-                    m_Owner.OnSkillChanged(this);
+                if (m_DataParent.OnSkillChanged != null)
+                    m_DataParent.OnSkillChanged(this);
             }
         }
         public float ValueUnmodified
@@ -102,8 +102,8 @@ namespace UltimaXNA.Ultima.Player
             set
             {
                 m_valueUnmodified = value;
-                if (m_Owner.OnSkillChanged != null)
-                    m_Owner.OnSkillChanged(this);
+                if (m_DataParent.OnSkillChanged != null)
+                    m_DataParent.OnSkillChanged(this);
             }
         }
         public byte LockType
@@ -112,8 +112,8 @@ namespace UltimaXNA.Ultima.Player
             set
             {
                 m_lockType = value;
-                if (m_Owner.OnSkillChanged != null)
-                    m_Owner.OnSkillChanged(this);
+                if (m_DataParent.OnSkillChanged != null)
+                    m_DataParent.OnSkillChanged(this);
             }
         }
         public float Cap
@@ -122,14 +122,14 @@ namespace UltimaXNA.Ultima.Player
             set
             {
                 m_cap = value;
-                if (m_Owner.OnSkillChanged != null)
-                    m_Owner.OnSkillChanged(this);
+                if (m_DataParent.OnSkillChanged != null)
+                    m_DataParent.OnSkillChanged(this);
             }
         }
 
-        public SkillEntry(SkillData owner, int id, int index, bool useButton, string name, float value, float unmodified, byte locktype, float cap)
+        public SkillEntry(SkillData dataParent, int id, int index, bool useButton, string name, float value, float unmodified, byte locktype, float cap)
         {
-            m_Owner = owner;
+            m_DataParent = dataParent;
             ID = id;
             Index = index;
             HasUseButton = useButton;

--- a/dev/Ultima/UI/Controls/AGumpPic.cs
+++ b/dev/Ultima/UI/Controls/AGumpPic.cs
@@ -1,0 +1,79 @@
+﻿/***************************************************************************
+ *   AGumpPic.cs
+ *   
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ ***************************************************************************/
+
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using UltimaXNA.Core.Graphics;
+using UltimaXNA.Core.UI;
+using UltimaXNA.Ultima.IO;
+
+namespace UltimaXNA.Ultima.UI.Controls
+{
+    class AGumpPic : AControl
+    {
+        protected Texture2D m_Texture = null;
+        private int m_LastFrameGumpID = -1;
+
+        internal int GumpID
+        {
+            get;
+            set;
+        }
+
+        internal int Hue
+        {
+            get;
+            set;
+        }
+
+        internal bool IsPaperdoll
+        {
+            get;
+            set;
+        }
+
+        public AGumpPic(AControl parent)
+            : base(parent)
+        {
+            MakeThisADragger();
+        }
+
+        protected void buildGumpling(int x, int y, int gumpID, int hue)
+        {
+            Position = new Point(x, y);
+            GumpID = gumpID;
+            Hue = hue;
+        }
+
+        public override void Update(double totalMS, double frameMS)
+        {
+            if (m_Texture == null || GumpID != m_LastFrameGumpID)
+            {
+                m_LastFrameGumpID = GumpID;
+                m_Texture = GumpData.GetGumpXNA(GumpID);
+                Size = new Point(m_Texture.Width, m_Texture.Height);
+            }
+
+            base.Update(totalMS, frameMS);
+        }
+
+        protected override bool IsPointWithinControl(int x, int y)
+        {
+            ushort[] pixelData;
+            pixelData = new ushort[1];
+            m_Texture.GetData<ushort>(0, new Rectangle(x, y, 1, 1), pixelData, 0, 1);
+            if (pixelData[0] > 0)
+                return true;
+            else
+                return false;
+        }
+    }
+}

--- a/dev/Ultima/UI/Controls/Button.cs
+++ b/dev/Ultima/UI/Controls/Button.cs
@@ -69,16 +69,16 @@ namespace UltimaXNA.Ultima.UI.Controls
 
         UserInterfaceService m_UserInterface;
 
-        public Button(AControl owner)
-            : base(owner)
+        public Button(AControl parent)
+            : base(parent)
         {
             HandlesMouseInput = true;
 
             m_UserInterface = ServiceRegistry.GetService<UserInterfaceService>();
         }
 
-        public Button(AControl owner, string[] arguements)
-            : this(owner)
+        public Button(AControl parent, string[] arguements)
+            : this(parent)
         {
             int x, y, gumpID1, gumpID2, buttonType, param, buttonID;
             x = Int32.Parse(arguements[1]);
@@ -91,8 +91,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, gumpID1, gumpID2, (ButtonTypes)buttonType, param, buttonID);
         }
 
-        public Button(AControl owner, int x, int y, int gumpID1, int gumpID2, ButtonTypes buttonType, int param, int buttonID)
-            : this(owner)
+        public Button(AControl parent, int x, int y, int gumpID1, int gumpID2, ButtonTypes buttonType, int param, int buttonID)
+            : this(parent)
         {
             buildGumpling(x, y, gumpID1, gumpID2, buttonType, param, buttonID);
         }

--- a/dev/Ultima/UI/Controls/CheckBox.cs
+++ b/dev/Ultima/UI/Controls/CheckBox.cs
@@ -21,14 +21,14 @@ namespace UltimaXNA.Ultima.UI.Controls
             protected set;
         }
 
-        public CheckBox(AControl owner)
-            : base(owner)
+        public CheckBox(AControl parent)
+            : base(parent)
         {
             HandlesMouseInput = true;
         }
 
-        public CheckBox(AControl owner, string[] arguements, string[] lines)
-            : this(owner)
+        public CheckBox(AControl parent, string[] arguements, string[] lines)
+            : this(parent)
         {
             int x, y, inactiveID, activeID, switchID;
             bool initialState;
@@ -43,8 +43,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, inactiveID, activeID, initialState, switchID);
         }
 
-        public CheckBox(AControl owner, int x, int y, int inactiveID, int activeID, bool initialState, int switchID)
-            : this(owner)
+        public CheckBox(AControl parent, int x, int y, int inactiveID, int activeID, bool initialState, int switchID)
+            : this(parent)
         {
             buildGumpling(x, y, inactiveID, activeID, initialState, switchID);
         }

--- a/dev/Ultima/UI/Controls/CheckerTrans.cs
+++ b/dev/Ultima/UI/Controls/CheckerTrans.cs
@@ -50,14 +50,14 @@ namespace UltimaXNA.Ultima.UI.Controls
             }
         }
 
-        public CheckerTrans(AControl owner)
-            : base(owner)
+        public CheckerTrans(AControl parent)
+            : base(parent)
         {
 
         }
 
-        public CheckerTrans(AControl owner, string[] arguements)
-            : this(owner)
+        public CheckerTrans(AControl parent, string[] arguements)
+            : this(parent)
         {
             int x, y, width, height;
             x = Int32.Parse(arguements[1]);
@@ -68,8 +68,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, width, height);
         }
 
-        public CheckerTrans(AControl owner, int x, int y, int width, int height)
-            : this(owner)
+        public CheckerTrans(AControl parent, int x, int y, int width, int height)
+            : this(parent)
         {
             buildGumpling(x, y, width, height);
         }

--- a/dev/Ultima/UI/Controls/ColorPicker.cs
+++ b/dev/Ultima/UI/Controls/ColorPicker.cs
@@ -56,22 +56,22 @@ namespace UltimaXNA.Ultima.UI.Controls
 
         UserInterfaceService m_UserInterface;
 
-        public ColorPicker(AControl owner)
-            : base(owner)
+        public ColorPicker(AControl parent)
+            : base(parent)
         {
             HandlesMouseInput = true;
 
             m_UserInterface = ServiceRegistry.GetService<UserInterfaceService>();
         }
 
-        public ColorPicker(AControl owner, Rectangle area, int swatchWidth, int swatchHeight, int[] hues)
-            : this(owner)
+        public ColorPicker(AControl parent, Rectangle area, int swatchWidth, int swatchHeight, int[] hues)
+            : this(parent)
         {
             buildGumpling(area, swatchWidth, swatchHeight, hues);
         }
 
-        public ColorPicker(AControl owner, Rectangle closedArea, Rectangle openArea, int swatchWidth, int swatchHeight, int[] hues)
-            : this(owner)
+        public ColorPicker(AControl parent, Rectangle closedArea, Rectangle openArea, int swatchWidth, int swatchHeight, int[] hues)
+            : this(parent)
         {
             m_openArea = openArea;
             buildGumpling(closedArea, swatchWidth, swatchHeight, hues);
@@ -127,10 +127,10 @@ namespace UltimaXNA.Ultima.UI.Controls
             {
                 if (m_ChildColorPicker == null)
                 {
-                    m_ChildColorPicker = new ColorPicker(Owner, m_openArea, m_hueWidth, m_hueHeight, m_hues);
+                    m_ChildColorPicker = new ColorPicker(Parent, m_openArea, m_hueWidth, m_hueHeight, m_hues);
                     m_ChildColorPicker.IsChild = true;
                     m_ChildColorPicker.Parent = this;
-                    Owner.AddControl(m_ChildColorPicker, this.Page);
+                    Parent.AddControl(m_ChildColorPicker, this.Page);
                 }
                 else
                 {

--- a/dev/Ultima/UI/Controls/ColorPicker.cs
+++ b/dev/Ultima/UI/Controls/ColorPicker.cs
@@ -36,7 +36,7 @@ namespace UltimaXNA.Ultima.UI.Controls
         }
 
         public bool IsChild = false;
-        public ColorPicker Parent = null;
+        public ColorPicker ParentColorPicker = null;
 
         public int HueValue
         {
@@ -120,16 +120,16 @@ namespace UltimaXNA.Ultima.UI.Controls
         {
             if (IsChild) // is a child
             {
-                Parent.Index = this.Index;
-                Parent.CloseChildPicker();
+                ParentColorPicker.Index = this.Index;
+                ParentColorPicker.CloseChildPicker();
             }
             else
             {
                 if (m_ChildColorPicker == null)
                 {
-                    m_ChildColorPicker = new ColorPicker(Parent, m_openArea, m_hueWidth, m_hueHeight, m_hues);
+                    m_ChildColorPicker = new ColorPicker(ParentColorPicker, m_openArea, m_hueWidth, m_hueHeight, m_hues);
                     m_ChildColorPicker.IsChild = true;
-                    m_ChildColorPicker.Parent = this;
+                    m_ChildColorPicker.ParentColorPicker = this;
                     Parent.AddControl(m_ChildColorPicker, this.Page);
                 }
                 else
@@ -147,7 +147,7 @@ namespace UltimaXNA.Ultima.UI.Controls
             {
                 int clickRow = x / (Width / m_hueWidth);
                 int clickColumn = y / (Height / m_hueHeight);
-                Parent.Index = Index = clickRow + clickColumn * m_hueWidth;
+                ParentColorPicker.Index = Index = clickRow + clickColumn * m_hueWidth;
             }
         }
 

--- a/dev/Ultima/UI/Controls/CroppedText.cs
+++ b/dev/Ultima/UI/Controls/CroppedText.cs
@@ -21,14 +21,14 @@ namespace UltimaXNA.Ultima.UI.Controls
         public string Text = string.Empty;
         RenderedText m_Texture;
 
-        public CroppedText(AControl owner)
-            : base(owner)
+        public CroppedText(AControl parent)
+            : base(parent)
         {
 
         }
 
-        public CroppedText(AControl owner, string[] arguements, string[] lines)
-            : this(owner)
+        public CroppedText(AControl parent, string[] arguements, string[] lines)
+            : this(parent)
         {
             int x, y, width, height, hue, textIndex;
             x = Int32.Parse(arguements[1]);
@@ -40,8 +40,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, width, height, hue, textIndex, lines);
         }
 
-        public CroppedText(AControl owner, int x, int y, int width, int height, int hue, int textIndex, string[] lines)
-            : this(owner)
+        public CroppedText(AControl parent, int x, int y, int width, int height, int hue, int textIndex, string[] lines)
+            : this(parent)
         {
             buildGumpling(x, y, width, height, hue, textIndex, lines);
         }

--- a/dev/Ultima/UI/Controls/DropDownList.cs
+++ b/dev/Ultima/UI/Controls/DropDownList.cs
@@ -38,8 +38,8 @@ namespace UltimaXNA.Ultima.UI.Controls
         UserInterfaceService m_UserInterface;
         IFont m_Font;
 
-        public DropDownList(AControl owner)
-            : base(owner)
+        public DropDownList(AControl parent)
+            : base(parent)
         {
             HandlesMouseInput = true;
 
@@ -47,8 +47,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             m_Font = ServiceRegistry.GetService<IUIResourceProvider>().GetAsciiFont(1);
         }
 
-        public DropDownList(AControl owner, int x, int y, int width, string[] items, int itemsVisible, int index, bool canBeNull)
-            : this(owner)
+        public DropDownList(AControl parent, int x, int y, int width, string[] items, int itemsVisible, int index, bool canBeNull)
+            : this(parent)
         {
             buildGumpling(x, y, width, items, itemsVisible, index, canBeNull);
         }
@@ -119,11 +119,11 @@ namespace UltimaXNA.Ultima.UI.Controls
         void onClickClosedList(AControl control, int x, int y, MouseButton button)
         {
             m_listOpen = true;
-            m_openResizePic = new ResizePic(Owner, X, Y, 3000, m_width, m_Font.Height * m_visibleItems + 8);
+            m_openResizePic = new ResizePic(Parent, X, Y, 3000, m_width, m_Font.Height * m_visibleItems + 8);
             m_openResizePic.MouseClickEvent += onClickOpenList;
             m_openResizePic.MouseOverEvent += onMouseOverOpenList;
             m_openResizePic.MouseOutEvent += onMouseOutOpenList;
-            ((Gump)Owner).AddControl(m_openResizePic, this.Page);
+            ((Gump)Parent).AddControl(m_openResizePic, this.Page);
 
             if (m_visibleItems > m_items.Count)
             {
@@ -133,14 +133,14 @@ namespace UltimaXNA.Ultima.UI.Controls
             // only show the scrollbar if we need to scroll
             if (m_visibleItems < m_items.Count)
             {
-                m_openScrollBar = new ScrollBar(Owner, X + m_width - 20, Y + 4, m_Font.Height * m_visibleItems, (m_canBeNull ? -1 : 0), m_items.Count - m_visibleItems, Index);
-                ((Gump)Owner).AddControl(m_openScrollBar, this.Page);
+                m_openScrollBar = new ScrollBar(Parent, X + m_width - 20, Y + 4, m_Font.Height * m_visibleItems, (m_canBeNull ? -1 : 0), m_items.Count - m_visibleItems, Index);
+                ((Gump)Parent).AddControl(m_openScrollBar, this.Page);
             }
             m_openLabels = new TextLabelAscii[m_visibleItems];
             for (int i = 0; i < m_visibleItems; i++)
             {
-                m_openLabels[i] = new TextLabelAscii(Owner, X + 4, Y + 5 + m_Font.Height * i, 1106, 1, string.Empty);
-                ((Gump)Owner).AddControl(m_openLabels[i], this.Page);
+                m_openLabels[i] = new TextLabelAscii(Parent, X + 4, Y + 5 + m_Font.Height * i, 1106, 1, string.Empty);
+                ((Gump)Parent).AddControl(m_openLabels[i], this.Page);
             }
         }
 

--- a/dev/Ultima/UI/Controls/EquipmentSlot.cs
+++ b/dev/Ultima/UI/Controls/EquipmentSlot.cs
@@ -35,8 +35,8 @@ namespace UltimaXNA.Ultima.UI.Controls
         private bool m_SendClickIfNoDoubleClick = false;
         private float m_SingleClickTime;
 
-        public EquipmentSlot(AControl owner, int x, int y, Mobile entity, EquipLayer layer)
-            : base(owner)
+        public EquipmentSlot(AControl parent, int x, int y, Mobile entity, EquipLayer layer)
+            : base(parent)
         {
             HandlesMouseInput = true;
 

--- a/dev/Ultima/UI/Controls/ExpandableScroll.cs
+++ b/dev/Ultima/UI/Controls/ExpandableScroll.cs
@@ -36,10 +36,10 @@ namespace UltimaXNA.Ultima.UI.Controls
         bool m_isExpanding = false;
         int m_isExpanding_InitialX, m_isExpanding_InitialY, m_isExpanding_InitialHeight;
 
-        public ExpandableScroll(AControl owner, int x, int y, int height)
+        public ExpandableScroll(AControl parent, int x, int y, int height)
             : base(0, 0)
         {
-            Owner = owner;
+            Parent = parent;
             Position = new Point(x, y);
             m_expandableScrollHeight = height;
             MakeThisADragger();

--- a/dev/Ultima/UI/Controls/GumpPic.cs
+++ b/dev/Ultima/UI/Controls/GumpPic.cs
@@ -40,14 +40,14 @@ namespace UltimaXNA.Ultima.UI.Controls
             set;
         }
 
-        public GumpPic(AControl owner)
-            : base(owner)
+        public GumpPic(AControl parent)
+            : base(parent)
         {
             MakeThisADragger();
         }
 
-        public GumpPic(AControl owner, string[] arguements)
-            : this(owner)
+        public GumpPic(AControl parent, string[] arguements)
+            : this(parent)
         {
             int x, y, gumpID, hue = 0;
             x = Int32.Parse(arguements[1]);
@@ -62,8 +62,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, gumpID, hue);
         }
 
-        public GumpPic(AControl owner, int x, int y, int gumpID, int hue)
-            : this(owner)
+        public GumpPic(AControl parent, int x, int y, int gumpID, int hue)
+            : this(parent)
         {
             buildGumpling(x, y, gumpID, hue);
         }

--- a/dev/Ultima/UI/Controls/GumpPic.cs
+++ b/dev/Ultima/UI/Controls/GumpPic.cs
@@ -17,37 +17,10 @@ using UltimaXNA.Ultima.IO;
 
 namespace UltimaXNA.Ultima.UI.Controls
 {
-    class GumpPic : AControl
+    class GumpPic : AGumpPic
     {
-        protected Texture2D m_Texture = null;
-        private int m_LastFrameGumpID = -1;
-
-        internal int GumpID
-        {
-            get;
-            set;
-        }
-
-        internal int Hue
-        {
-            get;
-            set;
-        }
-
-        internal bool IsPaperdoll
-        {
-            get;
-            set;
-        }
-
-        public GumpPic(AControl parent)
-            : base(parent)
-        {
-            MakeThisADragger();
-        }
-
         public GumpPic(AControl parent, string[] arguements)
-            : this(parent)
+            : base(parent)
         {
             int x, y, gumpID, hue = 0;
             x = Int32.Parse(arguements[1]);
@@ -63,28 +36,9 @@ namespace UltimaXNA.Ultima.UI.Controls
         }
 
         public GumpPic(AControl parent, int x, int y, int gumpID, int hue)
-            : this(parent)
+            : base(parent)
         {
             buildGumpling(x, y, gumpID, hue);
-        }
-
-        void buildGumpling(int x, int y, int gumpID, int hue)
-        {
-            Position = new Point(x, y);
-            GumpID = gumpID;
-            Hue = hue;
-        }
-
-        public override void Update(double totalMS, double frameMS)
-        {
-            if (m_Texture == null || GumpID != m_LastFrameGumpID)
-            {
-                m_LastFrameGumpID = GumpID;
-                m_Texture = GumpData.GetGumpXNA(GumpID);
-                Size = new Point(m_Texture.Width, m_Texture.Height);
-            }
-
-            base.Update(totalMS, frameMS);
         }
 
         public override void Draw(SpriteBatchUI spriteBatch, Point position)
@@ -94,15 +48,6 @@ namespace UltimaXNA.Ultima.UI.Controls
             base.Draw(spriteBatch, position);
         }
 
-        protected override bool IsPointWithinControl(int x, int y)
-        {
-            ushort[] pixelData;
-            pixelData = new ushort[1];
-            m_Texture.GetData<ushort>(0, new Rectangle(x, y, 1, 1), pixelData, 0, 1);
-            if (pixelData[0] > 0)
-                return true;
-            else
-                return false;
-        }
+        
     }
 }

--- a/dev/Ultima/UI/Controls/GumpPicBackpack.cs
+++ b/dev/Ultima/UI/Controls/GumpPicBackpack.cs
@@ -11,8 +11,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             protected set;
         }
 
-        public GumpPicBackpack(AControl owner, int x, int y, Item backpack)
-            : base(owner, x, y, 0xC4F6, 0)
+        public GumpPicBackpack(AControl parent, int x, int y, Item backpack)
+            : base(parent, x, y, 0xC4F6, 0)
         {
             BackpackItem = backpack;
         }

--- a/dev/Ultima/UI/Controls/GumpPicContainer.cs
+++ b/dev/Ultima/UI/Controls/GumpPicContainer.cs
@@ -18,8 +18,8 @@ namespace UltimaXNA.Ultima.UI.Controls
         Container m_containerItem;
         public Container Item { get { return m_containerItem; } }
 
-        public GumpPicContainer(AControl owner, int x, int y, int gumpID, int hue, Container containerItem)
-            : base(owner, x, y, gumpID, hue)
+        public GumpPicContainer(AControl parent, int x, int y, int gumpID, int hue, Container containerItem)
+            : base(parent, x, y, gumpID, hue)
         {
             m_containerItem = containerItem;
         }

--- a/dev/Ultima/UI/Controls/GumpPicTiled.cs
+++ b/dev/Ultima/UI/Controls/GumpPicTiled.cs
@@ -22,14 +22,14 @@ namespace UltimaXNA.Ultima.UI.Controls
         Texture2D m_bgGump = null;
         int m_gumpID;
 
-        public GumpPicTiled(AControl owner)
-            : base(owner)
+        public GumpPicTiled(AControl parent)
+            : base(parent)
         {
 
         }
 
-        public GumpPicTiled(AControl owner, string[] arguements)
-            : this(owner)
+        public GumpPicTiled(AControl parent, string[] arguements)
+            : this(parent)
         {
             int x, y, gumpID, width, height;
             x = Int32.Parse(arguements[1]);
@@ -40,8 +40,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, width, height, gumpID);
         }
 
-        public GumpPicTiled(AControl owner, int x, int y, int width, int height, int gumpID)
-            : this(owner)
+        public GumpPicTiled(AControl parent, int x, int y, int width, int height, int gumpID)
+            : this(parent)
         {
             buildGumpling(x, y, width, height, gumpID);
         }

--- a/dev/Ultima/UI/Controls/GumpPicWithWidth.cs
+++ b/dev/Ultima/UI/Controls/GumpPicWithWidth.cs
@@ -31,8 +31,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             }
         }
 
-        public GumpPicWithWidth(AControl owner, int x, int y, int gumpID, int hue, float percentWidth)
-            : base(owner, x, y, gumpID, hue)
+        public GumpPicWithWidth(AControl parent, int x, int y, int gumpID, int hue, float percentWidth)
+            : base(parent, x, y, gumpID, hue)
         {
             PercentWidthDrawn = percentWidth;
         }

--- a/dev/Ultima/UI/Controls/GumpPicWithWidth.cs
+++ b/dev/Ultima/UI/Controls/GumpPicWithWidth.cs
@@ -8,7 +8,7 @@ using UltimaXNA.Core.Graphics;
 
 namespace UltimaXNA.Ultima.UI.Controls
 {
-    class GumpPicWithWidth : GumpPic
+    class GumpPicWithWidth : AGumpPic
     {
         private float m_PercentWidthDrawn = 1.0f;
 
@@ -32,8 +32,9 @@ namespace UltimaXNA.Ultima.UI.Controls
         }
 
         public GumpPicWithWidth(AControl parent, int x, int y, int gumpID, int hue, float percentWidth)
-            : base(parent, x, y, gumpID, hue)
+            : base(parent)
         {
+            buildGumpling(x, y, gumpID, hue);
             PercentWidthDrawn = percentWidth;
         }
 
@@ -42,7 +43,7 @@ namespace UltimaXNA.Ultima.UI.Controls
             Vector3 hueVector = Utility.GetHueVector(Hue);
             int width = (int)(m_PercentWidthDrawn * Width);
             spriteBatch.Draw2D(m_Texture, new Rectangle(position.X, position.Y, width, Height), new Rectangle(0, 0, width, Height), hueVector);
-            // base.Draw(spriteBatch, position);  - commented this out because we don't want to draw GumpPic's Draw method, but UGH we do want to call AControl's...
+            base.Draw(spriteBatch, position);
         }
     }
 }

--- a/dev/Ultima/UI/Controls/HSliderBar.cs
+++ b/dev/Ultima/UI/Controls/HSliderBar.cs
@@ -59,15 +59,15 @@ namespace UltimaXNA.Ultima.UI.Controls
         private int m_sliderX;
         private HSliderBarStyle Style;
 
-        public HSliderBar(AControl owner)
-            : base(owner)
+        public HSliderBar(AControl parent)
+            : base(parent)
         {
             HandlesMouseInput = true;
             m_pairedSliders = new List<HSliderBar>();
         }
 
-        public HSliderBar(AControl owner, int x, int y, int width, int minValue, int maxValue, int value, HSliderBarStyle style)
-            : this(owner)
+        public HSliderBar(AControl parent, int x, int y, int width, int minValue, int maxValue, int value, HSliderBarStyle style)
+            : this(parent)
         {
             buildGumpling(x, y, width, minValue, maxValue, value, style);
         }

--- a/dev/Ultima/UI/Controls/HtmlGumpling.cs
+++ b/dev/Ultima/UI/Controls/HtmlGumpling.cs
@@ -80,8 +80,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             }
         }
 
-        public HtmlGumpling(AControl owner, string[] arguements, string[] lines)
-            : base(owner)
+        public HtmlGumpling(AControl parent, string[] arguements, string[] lines)
+            : base(parent)
         {
             int x, y, width, height, textIndex, background, scrollbar;
             x = Int32.Parse(arguements[1]);
@@ -95,8 +95,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, width, height, background, scrollbar, "<font color=#000>" + lines[textIndex]);
         }
 
-        public HtmlGumpling(AControl owner, int x, int y, int width, int height, int background, int scrollbar, string text)
-            : base(owner)
+        public HtmlGumpling(AControl parent, int x, int y, int width, int height, int background, int scrollbar, string text)
+            : base(parent)
         {
             buildGumpling(x, y, width, height, background, scrollbar, text);
         }

--- a/dev/Ultima/UI/Controls/ItemGumpling.cs
+++ b/dev/Ultima/UI/Controls/ItemGumpling.cs
@@ -40,8 +40,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             private set;
         }
 
-        public ItemGumpling(AControl owner, Item item)
-            : base(owner)
+        public ItemGumpling(AControl parent, Item item)
+            : base(parent)
         {
             buildGumpling(item);
             HandlesMouseInput = true;

--- a/dev/Ultima/UI/Controls/ItemGumplingPaperdoll.cs
+++ b/dev/Ultima/UI/Controls/ItemGumplingPaperdoll.cs
@@ -24,8 +24,8 @@ namespace UltimaXNA.Ultima.UI.Controls
         private int m_x, m_y;
         private bool m_isBuilt = false;
 
-        public ItemGumplingPaperdoll(AControl owner, int x, int y, Item item)
-            : base(owner, item)
+        public ItemGumplingPaperdoll(AControl parent, int x, int y, Item item)
+            : base(parent, item)
         {
             m_x = x;
             m_y = y;

--- a/dev/Ultima/UI/Controls/PaperDollInteractable.cs
+++ b/dev/Ultima/UI/Controls/PaperDollInteractable.cs
@@ -29,7 +29,7 @@ namespace UltimaXNA.Ultima.UI.Controls
         public PaperDollInteractable(AControl parent, int x, int y)
             : base(0, 0)
         {
-            Parent = owner;
+            Parent = parent;
             Position = new Point(x, y);
 
             m_World = ServiceRegistry.GetService<WorldModel>();

--- a/dev/Ultima/UI/Controls/PaperDollInteractable.cs
+++ b/dev/Ultima/UI/Controls/PaperDollInteractable.cs
@@ -26,10 +26,10 @@ namespace UltimaXNA.Ultima.UI.Controls
 
         WorldModel m_World;
 
-        public PaperDollInteractable(AControl owner, int x, int y)
+        public PaperDollInteractable(AControl parent, int x, int y)
             : base(0, 0)
         {
-            Owner = owner;
+            Parent = owner;
             Position = new Point(x, y);
 
             m_World = ServiceRegistry.GetService<WorldModel>();

--- a/dev/Ultima/UI/Controls/PaperdollLargeUninteractable.cs
+++ b/dev/Ultima/UI/Controls/PaperdollLargeUninteractable.cs
@@ -73,14 +73,14 @@ namespace UltimaXNA.Ultima.UI.Controls
             get { return m_equipmentSlots[(int)slot]; }
         }
 
-        PaperdollLargeUninteractable(AControl owner)
-            : base(owner)
+        PaperdollLargeUninteractable(AControl parent)
+            : base(parent)
         {
 
         }
 
-        public PaperdollLargeUninteractable(AControl owner, int x, int y)
-            : this(owner)
+        public PaperdollLargeUninteractable(AControl parent, int x, int y)
+            : this(parent)
         {
             Position = new Point(x, y);
         }

--- a/dev/Ultima/UI/Controls/RadioButton.cs
+++ b/dev/Ultima/UI/Controls/RadioButton.cs
@@ -11,8 +11,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             protected set;
         }
 
-        public RadioButton(AControl owner, int groupIndex, string[] arguements, string[] lines)
-            : base(owner, arguements, lines)
+        public RadioButton(AControl parent, int groupIndex, string[] arguements, string[] lines)
+            : base(parent, arguements, lines)
         {
             GroupIndex = groupIndex;
         }
@@ -20,9 +20,9 @@ namespace UltimaXNA.Ultima.UI.Controls
         protected override void OnMouseClick(int x, int y, MouseButton button)
         {
             base.OnMouseClick(x, y, button);
-            if (Owner != null)
+            if (Parent != null)
             {
-                foreach (AControl control in Owner.Children)
+                foreach (AControl control in Parent.Children)
                 {
                     if (control is RadioButton && (control as RadioButton).GroupIndex == GroupIndex)
                         (control as RadioButton).IsChecked = false;

--- a/dev/Ultima/UI/Controls/ResizePic.cs
+++ b/dev/Ultima/UI/Controls/ResizePic.cs
@@ -23,15 +23,15 @@ namespace UltimaXNA.Ultima.UI.Controls
         Texture2D[] m_bgGumps = null;
         int GumpID = 0;
 
-        public ResizePic(AControl owner)
-            : base(owner)
+        public ResizePic(AControl parent)
+            : base(parent)
         {
             m_bgGumps = new Texture2D[9];
             MakeThisADragger();
         }
 
-        public ResizePic(AControl owner, string[] arguements)
-            : this(owner)
+        public ResizePic(AControl parent, string[] arguements)
+            : this(parent)
         {
             int x, y, gumpID, width, height;
             x = Int32.Parse(arguements[1]);
@@ -42,14 +42,14 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, gumpID, width, height);
         }
 
-        public ResizePic(AControl owner, int x, int y, int gumpID, int width, int height)
-            : this(owner)
+        public ResizePic(AControl parent, int x, int y, int gumpID, int width, int height)
+            : this(parent)
         {
             buildGumpling(x, y, gumpID, width, height);
         }
 
-        public ResizePic(AControl owner, AControl createBackgroundAroundThisControl)
-            : this(owner)
+        public ResizePic(AControl parent, AControl createBackgroundAroundThisControl)
+            : this(parent)
         {
             buildGumpling(createBackgroundAroundThisControl.X - 4, 
                 createBackgroundAroundThisControl.Y - 4, 

--- a/dev/Ultima/UI/Controls/ScrollBar.cs
+++ b/dev/Ultima/UI/Controls/ScrollBar.cs
@@ -96,14 +96,14 @@ namespace UltimaXNA.Ultima.UI.Controls
         // ================================================================================
         // Ctors, Initialize, Update, and Draw
         // ================================================================================
-        public ScrollBar(AControl owner)
-            : base(owner)
+        public ScrollBar(AControl parent)
+            : base(parent)
         {
             HandlesMouseInput = true;
         }
 
-        public ScrollBar(AControl owner, int x, int y, int height, int minValue, int maxValue, int value)
-            : this(owner)
+        public ScrollBar(AControl parent, int x, int y, int height, int minValue, int maxValue, int value)
+            : this(parent)
         {
             Position = new Point(x, y);
             MinValue = minValue;

--- a/dev/Ultima/UI/Controls/ScrollFlag.cs
+++ b/dev/Ultima/UI/Controls/ScrollFlag.cs
@@ -89,14 +89,14 @@ namespace UltimaXNA.Ultima.UI.Controls
         // ================================================================================
         // Ctor, Initialize, Update, and Draw
         // ================================================================================
-        public ScrollFlag(AControl owner)
-            : base(owner)
+        public ScrollFlag(AControl parent)
+            : base(parent)
         {
             HandlesMouseInput = true;
         }
 
-        public ScrollFlag(AControl owner, int x, int y, int height, int minValue, int maxValue, int value)
-            : this(owner)
+        public ScrollFlag(AControl parent, int x, int y, int height, int minValue, int maxValue, int value)
+            : this(parent)
         {
             Position = new Point(x, y);
             m_SliderExtentTop = y;

--- a/dev/Ultima/UI/Controls/TextEntry.cs
+++ b/dev/Ultima/UI/Controls/TextEntry.cs
@@ -50,8 +50,8 @@ namespace UltimaXNA.Ultima.UI.Controls
 
         private UserInterfaceService m_UserInterface;
 
-        public TextEntry(AControl owner)
-            : base(owner)
+        public TextEntry(AControl parent)
+            : base(parent)
         {
             HandlesMouseInput = true;
             HandlesKeyboardFocus = true;
@@ -59,8 +59,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             m_UserInterface = ServiceRegistry.GetService<UserInterfaceService>();
         }
 
-        public TextEntry(AControl owner, string[] arguements, string[] lines)
-            : this(owner)
+        public TextEntry(AControl parent, string[] arguements, string[] lines)
+            : this(parent)
         {
             int x, y, width, height, hue, entryID, textIndex, limitSize = 0;
             x = Int32.Parse(arguements[1]);
@@ -77,8 +77,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, width, height, hue, entryID, limitSize, lines[textIndex]);
         }
 
-        public TextEntry(AControl owner, int x, int y, int width, int height, int hue, int entryID, int limitSize, string text)
-            : this(owner)
+        public TextEntry(AControl parent, int x, int y, int width, int height, int hue, int entryID, int limitSize, string text)
+            : this(parent)
         {
             buildGumpling(x, y, width, height, hue, entryID, limitSize, text);
         }
@@ -164,10 +164,10 @@ namespace UltimaXNA.Ultima.UI.Controls
             switch (e.KeyCode)
             {
                 case WinKeys.Tab:
-                    Owner.KeyboardTabToNextFocus(this);
+                    Parent.KeyboardTabToNextFocus(this);
                     break;
                 case WinKeys.Enter:
-                    Owner.ActivateByKeyboardReturn(EntryID, Text);
+                    Parent.ActivateByKeyboardReturn(EntryID, Text);
                     break;
                 case WinKeys.Back:
                     if (ReplaceDefaultTextOnFirstKeypress)

--- a/dev/Ultima/UI/Controls/TextLabel.cs
+++ b/dev/Ultima/UI/Controls/TextLabel.cs
@@ -41,14 +41,14 @@ namespace UltimaXNA.Ultima.UI.Controls
 
         RenderedText m_textRenderer;
 
-        public TextLabel(AControl owner)
-            : base(owner)
+        public TextLabel(AControl parent)
+            : base(parent)
         {
 
         }
 
-        public TextLabel(AControl owner, string[] arguements, string[] lines)
-            : this(owner)
+        public TextLabel(AControl parent, string[] arguements, string[] lines)
+            : this(parent)
         {
             int x, y, hue, textIndex;
             x = Int32.Parse(arguements[1]);
@@ -58,8 +58,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, hue, lines[textIndex]);
         }
 
-        public TextLabel(AControl owner, int x, int y, int hue, string text)
-            : this(owner)
+        public TextLabel(AControl parent, int x, int y, int hue, string text)
+            : this(parent)
         {
             buildGumpling(x, y, hue, text);
         }

--- a/dev/Ultima/UI/Controls/TextLabelAscii.cs
+++ b/dev/Ultima/UI/Controls/TextLabelAscii.cs
@@ -40,15 +40,15 @@ namespace UltimaXNA.Ultima.UI.Controls
             }
         }
 
-        public TextLabelAscii(AControl owner, int width = 400)
-            : base(owner)
+        public TextLabelAscii(AControl parent, int width = 400)
+            : base(parent)
         {
             m_Width = width;
             m_Rendered = new RenderedText(string.Empty, m_Width);
         }
 
-        public TextLabelAscii(AControl owner, int x, int y, int hue, int fontid, string text, int width = 400)
-            : this(owner, width)
+        public TextLabelAscii(AControl parent, int x, int y, int hue, int fontid, string text, int width = 400)
+            : this(parent, width)
         {
             buildGumpling(x, y, hue, fontid, text);
         }

--- a/dev/Ultima/UI/Controls/TextLabelAsciiCropped.cs
+++ b/dev/Ultima/UI/Controls/TextLabelAsciiCropped.cs
@@ -35,14 +35,14 @@ namespace UltimaXNA.Ultima.UI.Controls
             }
         }
 
-        public TextLabelAsciiCropped(AControl owner)
-            : base(owner)
+        public TextLabelAsciiCropped(AControl parent)
+            : base(parent)
         {
 
         }
 
-        public TextLabelAsciiCropped(AControl owner, int x, int y, int width, int height, int hue, int fontid, string text)
-            : this(owner)
+        public TextLabelAsciiCropped(AControl parent, int x, int y, int width, int height, int hue, int fontid, string text)
+            : this(parent)
         {
             buildGumpling(x, y, width, height, hue, fontid, text);
         }

--- a/dev/Ultima/UI/Controls/TilePic.cs
+++ b/dev/Ultima/UI/Controls/TilePic.cs
@@ -26,14 +26,14 @@ namespace UltimaXNA.Ultima.UI.Controls
         int Hue;
         int m_tileID;
 
-        public StaticPic(AControl owner)
-            : base(owner)
+        public StaticPic(AControl parent)
+            : base(parent)
         {
 
         }
 
-        public StaticPic(AControl owner, string[] arguements)
-            : this(owner)
+        public StaticPic(AControl parent, string[] arguements)
+            : this(parent)
         {
             int x, y, tileID, hue = 0;
             x = Int32.Parse(arguements[1]);
@@ -47,8 +47,8 @@ namespace UltimaXNA.Ultima.UI.Controls
             buildGumpling(x, y, tileID, hue);
         }
 
-        public StaticPic(AControl owner, int x, int y, int itemID, int hue)
-            : this(owner)
+        public StaticPic(AControl parent, int x, int y, int itemID, int hue)
+            : this(parent)
         {
             buildGumpling(x, y, itemID, hue);
         }

--- a/dev/Ultima/UI/Controls/WorldViewport.cs
+++ b/dev/Ultima/UI/Controls/WorldViewport.cs
@@ -29,8 +29,8 @@ namespace UltimaXNA.Ultima.UI.Controls
 
         private Vector2 m_InputMultiplier = Vector2.One;
 
-        public WorldViewport(AControl owner, int x, int y, int width, int height)
-            : base(owner)
+        public WorldViewport(AControl parent, int x, int y, int width, int height)
+            : base(parent)
         {
             Position = new Point(x, y);
             Size = new Point(width, height);

--- a/dev/Ultima/UI/LoginGumps/CreateCharAppearanceGump.cs
+++ b/dev/Ultima/UI/LoginGumps/CreateCharAppearanceGump.cs
@@ -30,7 +30,7 @@ namespace UltimaXNA.Ultima.UI.LoginGumps
             QuitButton
         }
 
-        public string Name { get { return m_Name.Text; } set { m_Name.Text = value; } }
+        public string Name { get { return m_TxtName.Text; } set { m_TxtName.Text = value; } }
         public int Gender { get { return m_Gender.Index; } set { } }
         public int Race { get { return 1; } set { } } // hard coded to human
         public int HairID
@@ -80,7 +80,7 @@ namespace UltimaXNA.Ultima.UI.LoginGumps
             set { m_FacialHairHue.HueValue = value; }
         }
 
-        TextEntry m_Name;
+        TextEntry m_TxtName;
         DropDownList m_Gender;
         DropDownList m_HairMale;
         DropDownList m_FacialHairMale;
@@ -98,9 +98,10 @@ namespace UltimaXNA.Ultima.UI.LoginGumps
             AddControl(new GumpPic(this, 0, 0, 5500, 0));
             // character name 
             AddControl(new GumpPic(this, 280, 53, 1801, 0));
-            m_Name = new TextEntry(this, 238, 70, 234, 20, 0, 0, 29, string.Empty);
-            AddControl(new ResizePic(this, m_Name));
-            AddControl(m_Name);
+            m_TxtName = new TextEntry(this, 238, 70, 234, 20, 0, 0, 29, string.Empty);
+            m_TxtName.HtmlTag = "<span color='#000' style='font-family:uni0;'>";
+            AddControl(new ResizePic(this, m_TxtName));
+            AddControl(m_TxtName);
             // character window
             AddControl(new GumpPic(this, 238, 98, 1800, 0));
             // paperdoll

--- a/dev/Ultima/UI/WorldGumps/ChatControl.cs
+++ b/dev/Ultima/UI/WorldGumps/ChatControl.cs
@@ -35,8 +35,8 @@ namespace UltimaXNA.Ultima.UI.WorldGumps
 
         int m_MessageHistoryIndex = -1;
 
-        public ChatControl(AControl owner, int x, int y, int width, int height)
-            : base(owner)
+        public ChatControl(AControl parent, int x, int y, int width, int height)
+            : base(parent)
         {
             Position = new Point(x, y);
             Size = new Point(width, height);

--- a/dev/Ultima/World/Input/WorldCursor.cs
+++ b/dev/Ultima/World/Input/WorldCursor.cs
@@ -119,8 +119,8 @@ namespace UltimaXNA.Ultima.World.Input
                         Container targetItem = (Container)((GumpPicContainer)target).Item;
                         MouseOverItem = targetItem;
 
-                        int x = (int)m_Input.MousePosition.X - m_HeldItemOffset.X - (target.X + target.Owner.X);
-                        int y = (int)m_Input.MousePosition.Y - m_HeldItemOffset.Y - (target.Y + target.Owner.Y);
+                        int x = (int)m_Input.MousePosition.X - m_HeldItemOffset.X - (target.X + target.Parent.X);
+                        int y = (int)m_Input.MousePosition.Y - m_HeldItemOffset.Y - (target.Y + target.Parent.Y);
                         DropHeldItemToContainer(targetItem, x, y);
                     }
                     else if (target is ItemGumplingPaperdoll || (target is GumpPic && ((GumpPic)target).IsPaperdoll) || (target is EquipmentSlot))

--- a/dev/Ultima/World/Input/WorldCursor.cs
+++ b/dev/Ultima/World/Input/WorldCursor.cs
@@ -215,10 +215,10 @@ namespace UltimaXNA.Ultima.World.Input
                                     // ItemGumping is the base class for all items, containers, and paperdoll items.
                                     mouseTargetingEventObject(((ItemGumpling)target).Item);
                                 }
-                                else if (target.OwnerTopmost is MobileHealthTrackerGump)
+                                else if (target.RootParent is MobileHealthTrackerGump)
                                 {
                                     // this is a mobile's mini-status gump (health bar, etc.) We can target it to cast spells on that mobile.
-                                    mouseTargetingEventObject(((MobileHealthTrackerGump)target.OwnerTopmost).Mobile);
+                                    mouseTargetingEventObject(((MobileHealthTrackerGump)target.RootParent).Mobile);
                                 }
                             }
                             else if (m_World.Input.IsMouseOverWorld)

--- a/dev/UltimaXNA.csproj
+++ b/dev/UltimaXNA.csproj
@@ -261,6 +261,7 @@
     <Compile Include="Ultima\Network\Client\GuildGumpRequestPacket.cs" />
     <Compile Include="Ultima\Network\Client\QuestGumpRequestPacket.cs" />
     <Compile Include="Ultima\Network\Server\ServerPingPacket.cs" />
+    <Compile Include="Ultima\UI\Controls\AGumpPic.cs" />
     <Compile Include="Ultima\UI\Controls\EquipmentSlot.cs" />
     <Compile Include="Ultima\UI\Controls\GumpPicWithWidth.cs" />
     <Compile Include="Ultima\UI\WorldGumps\ContextMenuGump.cs" />


### PR DESCRIPTION
Two of @jeffboulanger's suggestions (1) rename AControl.Owner -> AControl.Parent, and (the real improvement) AControl.TopmostOwner -> AControl.RootParent. Much better property naming. (2) GumpPicWithWidth now inherits from abstract base class AGumpPic (which has 99% of the functionality of GumpPic, which now also inherits from AGumpPic). Solves a problem I was having with overriding GumpPic's draw method.
