### PR TITLE
Fix for #367

### DIFF
--- a/dev/Ultima/UI/WorldGumps/SpellbookGump.cs
+++ b/dev/Ultima/UI/WorldGumps/SpellbookGump.cs
@@ -153,6 +153,7 @@ namespace UltimaXNA.Ultima.UI.WorldGumps
             // Begin checking which spells are in the spellbook and add them to m_Spells list
 
             int totalSpells = 0;
+            m_SpellList.Clear();
             for (int spellCircle = 0; spellCircle < 8; spellCircle++)
             {
                 for (int spellIndex = 1; spellIndex <= 8; spellIndex++)

--- a/dev/Ultima/World/Entities/Items/Containers/SpellBook.cs
+++ b/dev/Ultima/World/Entities/Items/Containers/SpellBook.cs
@@ -49,7 +49,7 @@ namespace UltimaXNA.Ultima.World.Entities.Items.Containers
 
         public void ReceiveSpellData(SpellBookTypes sbType, ulong sbBitfield)
         {
-            bool entityUpdated = true;
+            bool entityUpdated = false;
 
             if (BookType != sbType)
             {
@@ -57,7 +57,11 @@ namespace UltimaXNA.Ultima.World.Entities.Items.Containers
                 entityUpdated = true;
             }
 
-            m_SpellsBitfield = sbBitfield;
+            if (m_SpellsBitfield != sbBitfield)
+            {
+                m_SpellsBitfield = sbBitfield;
+                entityUpdated = true;
+            }
 
             if (entityUpdated && OnEntityUpdated != null)
                 OnEntityUpdated();


### PR DESCRIPTION
1. SpellBook entity OnEntityUpdated event is only called when the
   spellbook is actually updated.
2. SpellbookGump.m_SpellList is cleared when spellbook entity is
   updated.
