### PR TITLE
Fixed: bugs handling ServerList when more than one server is present

### DIFF
--- a/dev/Ultima/Login/Servers/ServerListEntry.cs
+++ b/dev/Ultima/Login/Servers/ServerListEntry.cs
@@ -50,7 +50,7 @@ namespace UltimaXNA.Ultima.Login.Servers
         public ServerListEntry(PacketReader reader)
         {
             index = (ushort)reader.ReadInt16();
-            name = reader.ReadString(30);
+            name = reader.ReadString(32);
             percentFull = reader.ReadByte();
             timezone = reader.ReadByte();
             address = (uint)reader.ReadInt32();

--- a/dev/Ultima/Login/States/SelectServerState.cs
+++ b/dev/Ultima/Login/States/SelectServerState.cs
@@ -64,7 +64,8 @@ namespace UltimaXNA.Ultima.Login.States
         {
             if (ServerList.List.Length == 1)
             {
-                OnSelectServer(0);
+                // HINT: First server is not always 0 index, expecially on POL
+                OnSelectServer(ServerList.List[0].Index);
             }
         }
 

--- a/dev/Ultima/UI/LoginGumps/SelectServerGump.cs
+++ b/dev/Ultima/UI/LoginGumps/SelectServerGump.cs
@@ -61,9 +61,12 @@ namespace UltimaXNA.Ultima.UI.LoginGumps
             AddControl(new HtmlGumpling(this, 402, 72, 50, 20, 0, 0, provider.GetString(1044577)), 1);
             AddControl(new HtmlGumpling(this, 472, 72, 80, 20, 0, 0, provider.GetString(1044578)), 1);
             // display the serverlist the server list.
+            int idx = 0;
             foreach (ServerListEntry e in ServerList.List)
             {
-                AddControl(new HtmlGumpling(this, 224, 104, 200, 20, 0, 0, "<big><a href=\"SHARD=" + e.Index + "\" style=\"text-decoration: none\">" + e.Name + "</a></big>"), 1);
+                // HINT: Do not use e.Index in place of idx: e.Index may non start from 0, or may contain holes, expecially on POL server
+                AddControl(new HtmlGumpling(this, 224, 104 + idx * 25, 200, 20, 0, 0, "<big><a href=\"SHARD=" + e.Index + "\" style=\"text-decoration: none\">" + e.Name + "</a></big>"), 1);
+                idx++;
             }
 
             // Page 2 - logging in to server ... with cancel login button


### PR DESCRIPTION
- Corrected server name string length in ServerListEntry
- Server names are no longer overlapping when displayed (y offset)
- No longer assuming server index is sequential and starting from 0
