### PR TITLE
Issue #401. ChatControl not registered error fix.

### DIFF
--- a/dev/Configuration/UltimaOnlineSettings.cs
+++ b/dev/Configuration/UltimaOnlineSettings.cs
@@ -22,6 +22,7 @@ namespace UltimaXNA.Configuration
 
         private string m_DataDirectory;
         private byte[] m_ClientVersion;
+        private bool m_IsClientVersionLocked;
 
         public UltimaOnlineSettings()
         {
@@ -30,6 +31,7 @@ namespace UltimaXNA.Configuration
             // Once we have this version working, we will attempt to support additional versions.
             // We will not support any issues you experience after changing this value.
             ClientVersion = new byte[] {6, 0, 6, 2};
+            IsClientVersionLocked = true;
         }
 
         /// <summary>
@@ -51,7 +53,32 @@ namespace UltimaXNA.Configuration
                 SetProperty(ref m_ClientVersion, value);
             }
         }
-        
+
+        /// <summary>
+        /// This flag is True then only UltimaOnlineSettings.ClientVersion will be used
+        /// to determine the client version.It protects from ExtendedClientFeatures
+        /// enable (Look at LoginClient.SendClientVersion method) on later clients.
+        /// Otherwise, if this flag is false we send to server 6.0.6.2 version
+        /// and server do not enable ExtendedClientFeatures, but our code will enable it
+        /// so we get wrong packet length on SupportedFeaturesPacket 
+        /// and catch an ChatControl not registered issue. See Issue #401.
+        /// Of course this is temporary decision while we are focusing on 6.0.6.2 version
+        /// and it's just protect you from crash on not supported client 
+        /// but you use it on your own risk.
+        /// </summary>
+        public bool IsClientVersionLocked
+        {
+            get { return m_IsClientVersionLocked; }
+            set
+            {
+                // Do not remove this check. See above.
+                if (!value)
+                    return;
+
+                SetProperty(ref m_IsClientVersionLocked, value);
+            }
+        }
+
         /// <summary>
         /// The directory where the Ultima Online resource files and executable are located.
         /// </summary>

--- a/dev/Ultima/Login/LoginClient.cs
+++ b/dev/Ultima/Login/LoginClient.cs
@@ -281,7 +281,7 @@ namespace UltimaXNA.Ultima.Login
             else
             {
                 ClientVersion.UnlockVersion();
-                if (ClientVersion.HasExtendedClientFeatures)
+                if (!Settings.UltimaOnline.IsClientVersionLocked && ClientVersion.HasExtendedClientFeatures)
                 {
                     Tracer.Info("Client version is greater than 6.0.14.2, enabling extended 0xB9 packet.");
                     Unregister(0xB9);


### PR DESCRIPTION
Fix for Issue #401. I had the same problem when using newer client (version 7.0.23.1). The problem is that we send to the server 6.0.6.2 version from UltimaOnlineSettings and server do not enable ExtendedClientFeatures, but then we enable it on client in LoginClient.SendClientVersion. So while we focus on 6.0.6.2 version I added new flag to lock this version explicit. More info in commit summary. So now you can run newer clients without errors but of course for your own risk.

P.S. This is my first pull request on github so sorry if I did something wrong. Please feel free to tell me how to improve my pull requests in future.
