### PR TITLE
Use platform directory separator char in Body

### DIFF
--- a/dev/Ultima/Data/Body.cs
+++ b/dev/Ultima/Data/Body.cs
@@ -35,7 +35,7 @@ namespace UltimaXNA.Ultima.Data
 
         static Body()
         {
-            string path = @"data\bodytable.cfg";
+            string path = @"data" + Path.DirectorySeparatorChar + "bodytable.cfg";
 
             if (File.Exists(path))
             {


### PR DESCRIPTION
Backslash doesn't work on non-Windows platforms.
