### PR TITLE
Replace native _lread call

### DIFF
--- a/dev/Core/Windows/NativeMethods.cs
+++ b/dev/Core/Windows/NativeMethods.cs
@@ -20,14 +20,6 @@ namespace UltimaXNA.Core.Windows
 
     class NativeMethods
     {
-        [DllImport("Kernel32")]
-        private unsafe static extern int _lread(SafeFileHandle hFile, void* lpBuffer, int wBytes);
-
-        internal static unsafe void ReadBuffer(SafeFileHandle ptr, void* buffer, int length)
-        {
-            _lread(ptr, buffer, length);
-        }
-
         [DllImport("Imm32.dll")]
         internal static extern IntPtr ImmGetContext(IntPtr hWnd);
 

--- a/dev/Ultima/Resources/TileMatrixData.cs
+++ b/dev/Ultima/Resources/TileMatrixData.cs
@@ -325,10 +325,7 @@ namespace UltimaXNA.Ultima.Resources
                         if (length > m_StaticTileLoadingBuffer.Length)
                             m_StaticTileLoadingBuffer = new byte[length];
 
-                        fixed (byte* pStaticTiles = m_StaticTileLoadingBuffer)
-                        {
-                            NativeMethods.ReadBuffer(m_StaticDataStream.SafeFileHandle, pStaticTiles, length);
-                        }
+                        m_StaticDataStream.Read(m_StaticTileLoadingBuffer, 0, length);
                         return m_StaticTileLoadingBuffer;
                     }
                 }
@@ -369,10 +366,7 @@ namespace UltimaXNA.Ultima.Resources
                 }
 
                 m_MapDataStream.Seek(ptr, SeekOrigin.Begin);
-                fixed (byte* pData = m_bufferedLandChunks[index])
-                {
-                    NativeMethods.ReadBuffer(m_MapDataStream.SafeFileHandle, pData, m_SizeLandChunkData);
-                }
+                m_MapDataStream.Read(m_bufferedLandChunks[index], 0, m_SizeLandChunkData);
                 Metrics.ReportDataRead(m_SizeLandChunkData);
                 return m_bufferedLandChunks[index];
             }

--- a/dev/Ultima/Resources/TileMatrixDataPatch.cs
+++ b/dev/Ultima/Resources/TileMatrixDataPatch.cs
@@ -64,10 +64,7 @@ namespace UltimaXNA.Ultima.Resources
                 m_LandPatchStream.Seek(ptr, SeekOrigin.Begin);
 
                 landData = new byte[192];
-                fixed (byte* pTiles = landData)
-                {
-                    NativeMethods.ReadBuffer(m_LandPatchStream.SafeFileHandle, pTiles, 192);
-                }
+                m_LandPatchStream.Read(landData, 0, 192);
                 return true;
             }
 
@@ -143,10 +140,7 @@ namespace UltimaXNA.Ultima.Resources
                     if (length > staticData.Length)
                         staticData = new byte[length];
 
-                    fixed (byte* pStaticTiles = staticData)
-                    {
-                        NativeMethods.ReadBuffer(m_StaticPatchStream.SafeFileHandle, pStaticTiles, length);
-                    }
+                    m_StaticPatchStream.Read(staticData, 0, length);
 
                     return true;
                 }


### PR DESCRIPTION
This removes unnecessary calls to `kernel32._lread` and replaces them with managed ones. I never really understood why a deprecated native call was used in the first place.
