### PR TITLE
Dirty fix for fallback map tile patch loading

### DIFF
--- a/dev/Ultima/Resources/TileMatrixData.cs
+++ b/dev/Ultima/Resources/TileMatrixData.cs
@@ -106,6 +106,7 @@ namespace UltimaXNA.Ultima.Resources
                     }
                     staticIndexStream = FileManager.GetFile("staidx{0}.mul", trammel);
                     m_StaticDataStream = FileManager.GetFile("statics{0}.mul", trammel);
+                    index = trammel;
                 }
                 else
                 {


### PR DESCRIPTION
This fixes loading patch data when you are in Felucca.