### PR TITLE
partial implementation of hue highlithing on mouse over events

### DIFF
--- a/dev/Ultima/UI/WorldGumps/MobileHealthTrackerGump.cs
+++ b/dev/Ultima/UI/WorldGumps/MobileHealthTrackerGump.cs
@@ -16,11 +16,12 @@ using UltimaXNA.Ultima.World;
 using UltimaXNA.Ultima.World.Entities.Mobiles;
 using UltimaXNA.Core.Network;
 using UltimaXNA.Ultima.Network.Client;
+using UltimaXNA.Ultima.World.EntityViews;
 #endregion
 
 namespace UltimaXNA.Ultima.UI.WorldGumps
 {
-    class MobileHealthTrackerGump : Gump
+    public class MobileHealthTrackerGump : Gump
     {
         public Mobile Mobile
         {
@@ -64,6 +65,8 @@ namespace UltimaXNA.Ultima.UI.WorldGumps
             {
                 AddControl(m_Background = new GumpPic(this, 0, 0, 0x0804, 0));
                 m_Background.MouseDoubleClickEvent += Background_MouseDoubleClickEvent;
+                m_Background.MouseOverEvent += Background_MouseOverEvent;
+                m_Background.MouseOutEvent += Background_MouseOutEvent;
                 m_BarBGs = new GumpPic[1];
                 AddControl(m_BarBGs[0] = new GumpPic(this, 34, 38, 0x0805, 0));
                 m_Bars = new GumpPicWithWidth[1];
@@ -78,10 +81,15 @@ namespace UltimaXNA.Ultima.UI.WorldGumps
                 m_BarBGs[i].HandlesMouseInput = false;
                 m_Bars[i].HandlesMouseInput = false;
             }
+
+            mobile.AddStatusBar(this);
         }
 
         public override void Dispose()
         {
+            Mobile.RemoveStatusBar();
+            m_Background.MouseOverEvent -= Background_MouseOverEvent;
+            m_Background.MouseOutEvent -= Background_MouseOutEvent;
             m_Background.MouseDoubleClickEvent -= Background_MouseDoubleClickEvent;
             base.Dispose();
         }
@@ -113,6 +121,17 @@ namespace UltimaXNA.Ultima.UI.WorldGumps
             }
 
             base.Update(totalMS, frameMS);
+        }
+
+        // Mouse events for finding out if player is hovering over a mobiles status bar gump
+        public bool IsMouseOverGump { get; private set; }
+        private void Background_MouseOverEvent(AControl caller, int x, int y)
+        {
+            IsMouseOverGump = true;
+        }
+        private void Background_MouseOutEvent(AControl caller, int x, int y)
+        {
+            IsMouseOverGump = false;
         }
 
         private void Background_MouseDoubleClickEvent(AControl caller, int x, int y, MouseButton button)

--- a/dev/Ultima/World/Entities/AEntity.cs
+++ b/dev/Ultima/World/Entities/AEntity.cs
@@ -16,6 +16,7 @@ using UltimaXNA.Ultima.World.EntityViews;
 using UltimaXNA.Ultima.World.Maps;
 using System;
 using System.Linq;
+using UltimaXNA.Ultima.UI.WorldGumps;
 #endregion
 
 namespace UltimaXNA.Ultima.World.Entities
@@ -282,6 +283,23 @@ namespace UltimaXNA.Ultima.World.Entities
                     i--;
                 }
             }
+        }
+
+        // ============================================================================================================
+        // Status Bar
+        // ============================================================================================================
+        private MobileHealthTrackerGump StatusBar = null;
+        public void AddStatusBar(MobileHealthTrackerGump statusBar)
+        {
+            StatusBar = statusBar;
+        }
+        public void RemoveStatusBar()
+        {
+            StatusBar = null;
+        }
+        public MobileHealthTrackerGump GetStatusBar()
+        {
+            return StatusBar;
         }
 
         // Update range

--- a/dev/Ultima/World/WorldClient.cs
+++ b/dev/Ultima/World/WorldClient.cs
@@ -637,6 +637,11 @@ namespace UltimaXNA.Ultima.World
         void ReceiveWarMode(WarModePacket p)
         {
             WorldModel.Entities.GetPlayerEntity().Flags.IsWarMode = p.WarMode;
+            // Removes last attacker from being highlighted
+            if (!p.WarMode)
+            {
+                m_World.Interaction.LastWarModeTarget = Serial.Null;
+            }
         }
 
         void ReceiveUpdateMana(UpdateManaPacket p)

--- a/dev/Ultima/World/WorldInteraction.cs
+++ b/dev/Ultima/World/WorldInteraction.cs
@@ -54,6 +54,15 @@ namespace UltimaXNA.Ultima.World {
                 m_Network.Send(new MobileQueryPacket(MobileQueryPacket.StatusType.BasicStatus, m_lastTarget));
             }
         }
+        private Serial m_lastWarModeTarget;
+        public Serial LastWarModeTarget
+        {
+            get { return m_lastWarModeTarget; }
+            set
+            {
+                m_lastWarModeTarget = value;
+            }
+        }
 
         /// <summary>
         /// For items, if server.expansion is less than AOS, sends single click packet.
@@ -84,6 +93,8 @@ namespace UltimaXNA.Ultima.World {
             else if (mobile.Notoriety == 0x1 || mobile.Notoriety == 0x3 || mobile.Notoriety == 0x4 || mobile.Notoriety == 0x5 || mobile.Notoriety == 0x6)
             {
                 m_Network.Send(new AttackRequestPacket(mobile.Serial));
+                // Set last war mode target for highlighting
+                LastWarModeTarget = mobile.Serial;
             }
             // CrimeQuery is enabled, ask before attacking others
             else if (Settings.UserInterface.CrimeQuery)
@@ -94,6 +105,8 @@ namespace UltimaXNA.Ultima.World {
             else
             {
                 m_Network.Send(new AttackRequestPacket(mobile.Serial));
+                // Set last war mode target for highlighting
+                LastWarModeTarget = mobile.Serial;
             }
         }
 


### PR DESCRIPTION
I'm not quite sure how the drawing happens for equipment on humanoids, so it is only 90% complete. When hovering the mouse over a humanoid in war mode, only the piece of equipment is hued, instead of the entire humanoid plus equipment. Looked at the code for awhile but I couldn't figure out what was causing this, as highlighting the status bar or attacking the target would highlight and hue correctly.

**TODO**:

- Get custom highlighting from client set options
- Fix humanoids with armour and clothing having only the item hovered over hued